### PR TITLE
Add initial Server interface and types

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/open-telemetry/opamp-go/server/types"
+)
+
+type Settings struct {
+	// Callbacks that the server will call after successful Attach/Start.
+	Callbacks types.Callbacks
+}
+
+type StartSettings struct {
+	Settings
+
+	// ListenEndpoint specifies the endpoint to listen on, e.g. "127.0.0.1:4320"
+	ListenEndpoint string
+
+	// Server's TLS configuration.
+	TLSConfig *tls.Config
+}
+
+type HTTPHandlerFunc func(http.ResponseWriter, *http.Request)
+
+type OpAMPServer interface {
+	// Attach prepares the OpAMP Server to begin handling requests from an existing
+	// http.Server. The returned HTTPHandlerFunc should be added as a handler to the
+	// desired http.Server by the caller and the http.Server should be started by
+	// the caller after that.
+	// For example:
+	//   handler, _ := server.Attach()
+	//   mux := http.NewServeMux()
+	//   mux.HandleFunc("/opamp", handler)
+	//   httpSrv := &http.Server{Handler:mux,Addr:"127.0.0.1:4320"}
+	//   httpSrv.ListenAndServe()
+	Attach(settings Settings) (HTTPHandlerFunc, error)
+
+	// Start an OpAMP Server and begin accepting connections. Starts its own http.Server
+	// using provided settings. This should block until the http.Server is ready to
+	// accept connections.
+	Start(settings StartSettings) error
+
+	// Stop accepting new connections and close all current connections. This should
+	// block until all connections are closed.
+	Stop(ctx context.Context) error
+}

--- a/server/types/callbacks.go
+++ b/server/types/callbacks.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"net/http"
+
+	"github.com/open-telemetry/opamp-go/internal/protobufs"
+)
+
+// ConnectionResponse is the return type of the OnConnecting callback.
+type ConnectionResponse struct {
+	Accept             bool
+	HTTPStatusCode     int
+	HTTPResponseHeader map[string]string
+}
+
+type Callbacks interface {
+	// The following callbacks will never be called concurrently for the same
+	// connection. They may be called concurrently for different connections.
+
+	// OnConnecting is called when there is a new incoming connection.
+	// The handler can examine the request and either accept or reject the connection.
+	// To accept:
+	//   Return ConnectionResponse with Accept=true.
+	//   HTTPStatusCode and HTTPResponseHeader are ignored.
+	//
+	// To reject:
+	//   Return ConnectionResponse with Accept=false. HTTPStatusCode MUST be set to
+	//   non-zero value to indicate the rejection reason (typically 401, 429 or 503).
+	//   HTTPResponseHeader may be optionally set (e.g. "Retry-After: 30").
+	OnConnecting(request *http.Request) ConnectionResponse
+
+	// OnConnected is called when the WebSocket connection is successfully established
+	// after OnConnecting() returns and the HTTP connection is upgraded to WebSocket.
+	OnConnected(conn Connection)
+
+	// OnMessage is called when a message is received from the connection. Can happen
+	// only after OnConnected().
+	OnMessage(conn Connection, message *protobufs.AgentToServer)
+
+	// OnDisconnect is called when a Disconnect message is received from the client
+	// identified by instanceUid through the specified connection. Note that this is
+	// not the same as disconnecting the connection, the Disconnect is a message that
+	// the clients should send before the actual disconnection.
+	OnDisconnect(conn Connection, instanceUid string)
+
+	// OnConnectionClose is called when the WebSocket connection is closed.
+	// Typically, preceded by OnDisconnect() unless the client misbehaves or the
+	// connection is lost.
+	OnConnectionClose(conn Connection)
+}

--- a/server/types/connection.go
+++ b/server/types/connection.go
@@ -1,0 +1,16 @@
+package types
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opamp-go/internal/protobufs"
+)
+
+// Connection represents one OpAMP WebSocket connections.
+// The implementation MUST be a comparable type so that it can be used as a map key.
+type Connection interface {
+	// Send a message. Should not be called concurrently for the same Connection instance.
+	// Blocks until the message is sent.
+	// Should return as soon as possible if the ctx is cancelled.
+	Send(ctx context.Context, message *protobufs.ServerToAgent) error
+}


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opamp-go/issues/16

This is similar to what we did for the Client: it introduces an interface
which can be implemented by the actual implementation later.