### PR TITLE
Delete unnecessary OnDisconnect

### DIFF
--- a/server/internal/callbacks.go
+++ b/server/internal/callbacks.go
@@ -11,7 +11,6 @@ type CallbacksStruct struct {
 	OnConnectingFunc      func(request *http.Request) types.ConnectionResponse
 	OnConnectedFunc       func(conn types.Connection)
 	OnMessageFunc         func(conn types.Connection, message *protobufs.AgentToServer)
-	OnDisconnectFunc      func(conn types.Connection, instanceUid string)
 	OnConnectionCloseFunc func(conn types.Connection)
 }
 
@@ -33,12 +32,6 @@ func (c CallbacksStruct) OnConnected(conn types.Connection) {
 func (c CallbacksStruct) OnMessage(conn types.Connection, message *protobufs.AgentToServer) {
 	if c.OnMessageFunc != nil {
 		c.OnMessageFunc(conn, message)
-	}
-}
-
-func (c CallbacksStruct) OnDisconnect(conn types.Connection, instanceUid string) {
-	if c.OnDisconnectFunc != nil {
-		c.OnDisconnectFunc(conn, instanceUid)
 	}
 }
 

--- a/server/types/callbacks.go
+++ b/server/types/callbacks.go
@@ -37,12 +37,6 @@ type Callbacks interface {
 	// only after OnConnected().
 	OnMessage(conn Connection, message *protobufs.AgentToServer)
 
-	// OnDisconnect is called when a Disconnect message is received from the client
-	// identified by instanceUid through the specified connection. Note that this is
-	// not the same as disconnecting the connection, the Disconnect is a message that
-	// the clients should send before the actual disconnection.
-	OnDisconnect(conn Connection, instanceUid string)
-
 	// OnConnectionClose is called when the WebSocket connection is closed.
 	// Typically, preceded by OnDisconnect() unless the client misbehaves or the
 	// connection is lost.


### PR DESCRIPTION
"Disconnect" is just a regular message type under AgentToServer message
which can be handled via OnMessage just like all other message. There is
no reason OnDisconnect needs to exit.