### PR TITLE
Fix client test case

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -107,7 +107,9 @@ func TestStopCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	err := client.Stop(ctx)
-	assert.ErrorIs(t, err, context.Canceled)
+	if err != nil {
+		assert.ErrorIs(t, err, context.Canceled)
+	}
 }
 
 func TestConnectWithServer(t *testing.T) {


### PR DESCRIPTION
This fixes the case when Stop returns without an error since
it manages to stop before the external context cancellation
is effective.