### PR TITLE
APIs for implementing supervisor and its configuration file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/supervisor/agent/agent.go
+++ b/supervisor/agent/agent.go
@@ -1,0 +1,64 @@
+package agent
+
+import "github.com/open-telemetry/opamp-go/protobufs"
+
+type Settings struct {
+	// Capabilities are the list of capabilities that this agent supports.
+	// See `protobufs.AgentCapabilities'.
+	Capabilities []string `koanf:"capabilities"`
+
+	// Attrs are any key-value pair that describes the identifying and
+	// non-identifying attributes of the agent.
+	Attrs map[string]string `koanf:"attrs"`
+
+	// ConfigSpec describes this agent's configuration source from which
+	// its effective configuration is read and to which the remote configuration
+	// is written.
+	ConfigSpec *ConfigSpec `koanf:"config"`
+
+	// PackageSpec describes the set of files that make this agent.
+	PackageSpec *PackageSpec `koanf:"package"`
+}
+
+// Identifier provides this agent's unique identification.
+type Identifier interface {
+	// Type returns the FQDN of this agent. For example, for an OpenTelemetry
+	// Collector this should return "io.opentelemetry.collector".
+	Type() string
+
+	// Version returns this agent's build version.
+	//
+	// Version may return an error if it is unable to determine the Agent's
+	// version. This is possible, for example, if the only way to retrieve
+	// the agent's version is to make an HTTP request and the request fails.
+	Version() (string, error)
+
+	// InstanceID uniquely identifies this agent in combination with other
+	// attributes.
+	InstanceID() (string, error)
+
+	// Namespace return this agent's namespace. For example, for an OpenTelemetry
+	// Collector, this is equivalent to `service.namespace'.
+	Namespace() string
+}
+
+// Agent represents a long running process that allows for management via a
+// supervisor. OpenTelemetry Collector or a FluentBit daemon are some of the
+// examples of an Agent.
+type Agent interface {
+	// Identifier allows several identifying attributes like the Agent's
+	// type, version and namespace to be returned.
+	Identifier
+
+	// GetNonIdentifyingAttrs returns attributes that do not necessarily help
+	// identify the agent, but describe where it runs.
+	GetNonIdentifyingAttrs() ([]*protobufs.KeyValue, error)
+
+	// Commander allows the agent to be started, stopped and restarted.
+	// See `agent.Commander`
+	Commander
+
+	// HealthChecker allows the agent's health to be monitored.
+	// See `agent.HealthChecker`
+	HealthChecker
+}

--- a/supervisor/agent/commander.go
+++ b/supervisor/agent/commander.go
@@ -1,0 +1,68 @@
+package agent
+
+import "context"
+
+// CommandConfig describes a systemd-based or an exec-based way of starting,
+// stopping and restarting the agent. Only one of `ExecConfig' or `SystemdConfig'
+// must be specified.
+type CommandConfig struct {
+	// Name is the path to the Agent executable. Path can be relative
+	// or absolute. A relative path should be relative to the CWD of the
+	// supervisor.
+	Name string `koanf:"name"`
+
+	// Args are the set of command-line arguments that must be specified along
+	// with the executable to start the Agent.
+	Args []string `koanf:"args"`
+}
+
+// Process represents information related to a running agent process.
+type Process struct {
+	// PID is the process id of the agent process that is currently running.
+	//
+	// A watchdog may use this PID to stop this agent process at a later time.
+	PID int
+
+	// Done is the channel which is set when the process terminates. This allows
+	// for async start of the agent followed by a continuous monitoring of its
+	// termination.
+	//
+	// A watchdog, for instance, can wait on this channel to listen to process
+	// termination event and restart the agent if needed.
+	Done <-chan struct{}
+}
+
+// Commander allows the agent to be started, stopped and restarted at various
+// points in the supervisor's lifetime.
+type Commander interface {
+	// Start the agent process and return the `Process' information. The
+	// actual mechanism for starting the process depends on whether or not
+	// the agent is managed by a `systemd'-like facility.
+	//
+	// Start MUST NOT block and return whether or not it was able to successfully
+	// launch the agent process from an OS perspective, i.e., the process may
+	// start but fail sometime later.
+	//
+	// Start returns the process information pertaining to the new agent process
+	// or an error if the process could not be successfully restarted.
+	Start() (*Process, error)
+
+	// Stop the agent process as defined by `process'. The actual mechanism
+	// for stopping the process depends on whether or not the agent is managed
+	// by a `systemd'-like facility.
+	//
+	// Stop MUST wait for the process to be terminated from an OS perspective.
+	Stop(ctx context.Context, process *Process) error
+
+	// Restart the agent process as defined by `process'.
+	//
+	// Restart, most likely, is implemented as a Stop followed by a Start in
+	// which case the Stop part might block until the process terminates.
+	//
+	// Restart returns the process information pertaining to the new agent process
+	// or an error if the process could not be successfully restarted.
+	Restart(
+		ctx context.Context,
+		process *Process,
+	) (*Process, error)
+}

--- a/supervisor/agent/configurer.go
+++ b/supervisor/agent/configurer.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"context"
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+// ConfigSpec describes the location of the this Agent's configuration.
+// Currently, only a file-based configuration is allowed on which the
+// local-read and remote-write are performed.
+type ConfigSpec struct {
+	// File is the path to this Agent's configuration file.
+	File string `koanf:"file"`
+
+	// AutoReload is true if this agent must be restarted on configuration
+	// change and false otherwise.
+	AutoReload bool `koanf:"auto_reload"`
+}
+
+// Configurer allows the Agent's effective configuration to be fetched and
+// updated.
+type Configurer interface {
+	// LoadEffectiveConfig loads this agent's effective configuration.
+	//
+	// Effective configuration is obtained by merging the configuration elements
+	// from various sources known to this agent. Typically, the effective
+	// configuration, in most cases, is just loaded from the agent's local
+	// configuration file.
+	LoadEffectiveConfig(configSpec *ConfigSpec) (*protobufs.EffectiveConfig, error)
+
+	// UpdateConfig updates this agent's configuration with the specified
+	// remote configuration.
+	//
+	// UpdateConfig MUST restart the agent if `auto_reload' is true for this
+	// agent.
+	//
+	// UpdateConfig, on restarting an agent after configuration update, MUST
+	// wait for the agent to become healthy before returning successfully. The
+	// provided Watcher can be used to restart the agent and wait until its
+	// healthy before returning success.
+	//
+	// If the agent remains unhealthy after the update, the agent must be
+	// reverted to the previously known configuration.
+	//
+	// UpdateConfig returns the effective configuration after successfully
+	// applying the remote configuration.
+	UpdateConfig(
+		ctx context.Context,
+		configSpec *ConfigSpec,
+		remoteConfig *protobufs.AgentRemoteConfig,
+		watcher Watcher,
+	) (*protobufs.EffectiveConfig, error)
+}

--- a/supervisor/agent/healthchecker.go
+++ b/supervisor/agent/healthchecker.go
@@ -1,0 +1,38 @@
+package agent
+
+import "time"
+
+// HealthCheckConfig describes how the agent's health is monitored.
+type HealthCheckConfig struct {
+	// URL at which the health-check must be done. The health check is considered
+	// successful if a GET on the URL responds with a code between 200 and 400.
+	URL          string        `koanf:"url"`
+
+	// InitialDelay is duration that the supervisor should wait before making
+	// the first health-check after a Start or Restart of the agent.
+	InitialDelay time.Duration `koanf:"initial_delay"`
+
+	// Period is the interval at which the supervisor should make the
+	// health-check requests.
+	Period       time.Duration `koanf:"period"`
+
+	// Timeout is the duration within which the agent must respond to a
+	// health-check after which it is deemed to have failed.
+	Timeout      time.Duration `koanf:"timeout"`
+
+	// SuccessThreshold is the minimum consecutive successes for the health-check
+	// to be considered successful after having failed.
+	SuccessThreshold int `koanf:"success_threshold"`
+
+	// FailureThreshold is the minimum number of times the health-check must
+	// fail after the initial failure for it to be restarted.
+	FailureThreshold int `koanf:"failure_threshold"`
+}
+
+// HealthChecker allows the agent's health, as described by the HealthCheckConfig,
+// to be monitored continuously after a Start or Restart.
+type HealthChecker interface {
+	// IsHealthy returns true if the agent is healthy according to the health
+	// check configuration and false otherwise.
+	IsHealthy() bool
+}

--- a/supervisor/agent/packager.go
+++ b/supervisor/agent/packager.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"context"
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+// PackageSpec describes what constitutes an agent package and is used to
+// implement the `protobufs.AgentPackageAvailable' message.
+type PackageSpec struct {
+	// Files are the set of, potential binary files, that make up the agent's
+	// package and must be updated as part of the `protobufs.AgentPackageAvailable'
+	// message.
+	Files map[string]string `koanf:"files"`
+}
+
+// Packager allows the agent's local package to be upgraded or downgraded from
+// a remote file.
+type Packager interface {
+	// Sync the remote package described in `protobufs.AgentPackageAvailable'
+	// with the locally available package as described by `PackageSpec'.
+	//
+	// Sync may check the content hash in the provided message to verify the
+	// integrity of the downloaded package and to avoid unnecessary downloads.
+	//
+	// Sync may check the version in the the provided message to avoid
+	// unnecessary downloads if the remote and local versions are the same.
+	//
+	// Sync may report download progress via the `onProgressFunc` callback.
+	//
+	// Sync may use the watcher to restart the agent after performing the
+	// necessary updates.
+	//
+	// It is recommended for Sync to take a backup of the files being updated
+	// so as to revert to it if the update is unsuccessful.
+	//
+	// Sync MUST return error if the package could not be downloaded, verified,
+	// or installed.
+	Sync(
+		ctx context.Context,
+		pkg *protobufs.AgentPackageAvailable,
+		watcher Watcher,
+		onProgressFunc func(file string, percent float32)) error
+}

--- a/supervisor/agent/watcher.go
+++ b/supervisor/agent/watcher.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"context"
+	"time"
+)
+
+// WatchConfig dictates the timing restrictions to be honored during an attempt
+// to start, stop or restart the agent.
+// restart the agent.
+type WatchConfig struct {
+	// CommandConfig describes how to exec the agent.
+	CommandConfig *CommandConfig `koanf:"command"`
+
+	// HealthCheckConfig describes how to monitor the agent's health.
+	HealthCheckConfig *HealthCheckConfig `koanf:"health_check"`
+
+	// MaxAttempts is the maximum number of attempts the agent is allowed to
+	// fail a START, STOP or RESTART operation.
+	MaxAttempts int `koanf:"max_attempts"`
+
+	// WaitBetweenAttempts is the duration to wait between successive attempts
+	// to START, STOP or RESTART the agent.
+	WaitBetweenAttempts time.Duration `koanf:"wait_between_attempts"`
+}
+
+type Watcher interface {
+	// Watch starts the agent and begins the monitoring of its health.
+	//
+	// Watch may block until the agent is started and the health check is
+	// successful as described by the configuration.
+	//
+	// Watch MUST NOT block forever, i.e., any long running monitoring logic
+	// must be done in a separate Go routine if necessary.
+	//
+	// Watch returns an error if the agent cannot be started per the specified
+	// configuration or the initial health check fails.
+	//
+	// Watch should only be called once (preferably at the start of the
+	// supervisor).
+	Watch(ctx context.Context) error
+
+	// Restart the monitored agent.
+	//
+	// Restart may block until the agent is restarted and the health check
+	// is successful as described by the configuration.
+	//
+	// Restart MUST NOT block forever, i.e., any long running monitoring logic
+	// post-restart must be done in a separate Go routine if necessary.
+	//
+	// Restart returns an error if the agent cannot be restarted per the
+	// specified configuration
+	Restart(ctx context.Context) error
+
+	// Shutdown the watcher along with the monitoring of the agent's health.
+	Shutdown(ctx context.Context) error
+}

--- a/supervisor/callbacks.go
+++ b/supervisor/callbacks.go
@@ -1,0 +1,79 @@
+package supervisor
+
+import (
+	"context"
+	"github.com/open-telemetry/opamp-go/client/types"
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+var _ types.Callbacks = (*supervisor)(nil)
+
+func (s *supervisor) OnConnect() {
+	s.logger.Debugf("Connected to the server")
+}
+
+func (s *supervisor) OnConnectFailed(err error) {
+	s.logger.Errorf("Failed to connect to the server: %v", err)
+}
+
+func (s *supervisor) OnError(err *protobufs.ServerErrorResponse) {
+	s.logger.Errorf("Server returned an error response: %v", err.ErrorMessage)
+}
+
+func (s *supervisor) OnRemoteConfig(
+	ctx context.Context, remoteConfig *protobufs.AgentRemoteConfig,
+) (*protobufs.EffectiveConfig, error) {
+	return s.configurer.UpdateConfig(
+		ctx,
+		s.config.AgentSettings.ConfigSpec,
+		remoteConfig,
+		s.watcher)
+}
+
+func (s *supervisor) OnAgentPackageAvailable(
+	pkg *protobufs.AgentPackageAvailable, _ types.AgentPackageSyncer,
+) error {
+	return s.packager.Sync(
+		context.Background(), // TODO: the context should be provided on the callback
+		pkg,
+		s.watcher,
+		func(file string, percent float32) {
+			s.logger.Debugf("Downloading %q (%f)", file, percent)
+		},
+	)
+}
+
+// !!!!!!!!!!!!!!!!!!!!
+// !!! UNIMPLEMENTED!!!
+// !!!!!!!!!!!!!!!!!!!!
+
+func (s *supervisor) OnOpampConnectionSettings(
+	ctx context.Context, settings *protobufs.ConnectionSettings,
+) error {
+	panic("unimplemented")
+}
+
+func (s *supervisor) OnOpampConnectionSettingsAccepted(settings *protobufs.ConnectionSettings) {
+	panic("unimplemented")
+}
+
+func (s *supervisor) OnOwnTelemetryConnectionSettings(
+	ctx context.Context, telemetryType types.OwnTelemetryType,
+	settings *protobufs.ConnectionSettings,
+) error {
+	panic("unimplemented")
+}
+
+func (s *supervisor) OnOtherConnectionSettings(
+	ctx context.Context, name string, settings *protobufs.ConnectionSettings,
+) error {
+	panic("unimplemented")
+}
+
+func (s *supervisor) OnAddonsAvailable(
+	ctx context.Context,
+	addons *protobufs.AddonsAvailable,
+	syncer types.AddonSyncer,
+) error {
+	panic("unimplemented")
+}

--- a/supervisor/cmd/main.go
+++ b/supervisor/cmd/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"flag"
+	"github.com/open-telemetry/opamp-go/supervisor"
+	"log"
+	"os"
+)
+
+func main() {
+	var configFile string
+	flag.StringVar(&configFile, "c", "", "Supervisor configuration file")
+	flag.Parse()
+
+	logger := &supervisor.Logger{Logger: log.Default()}
+	if err := supervisor.New(configFile, logger).Start(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/supervisor/config.go
+++ b/supervisor/config.go
@@ -1,0 +1,83 @@
+package supervisor
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/open-telemetry/opamp-go/supervisor/agent"
+)
+
+// TLSConfig describes basic client-side certificates to be used during
+// client-side TLS authentication.
+// TODO: these are just to fill in the gaps; not a lot of thought put into it.
+type TLSConfig struct {
+	// CertFile is the path to the client-side PEM-encoded file.
+	CertFile string
+	// KeyFile is the path to the key-file corresponding to the PEM file.
+	KeyFile string
+	// See tls.Config#InsecureSkipVerify.
+	InsecureSkipVerify bool
+}
+
+func (t *TLSConfig) loadTLSConfig() (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(t.CertFile, t.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load %q with %q", t.CertFile, t.KeyFile)
+	}
+	return &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: t.InsecureSkipVerify,
+	}, nil
+}
+
+// OpAMPServer describes how to connect to an OpAMP server.
+type OpAMPServer struct {
+	Endpoint  string     `kaonf:"endpoint"`
+	TLSConfig *TLSConfig `koanf:"tls_config"`
+}
+
+// Configuration describes this supervisor's configuration along with the
+// Agent that it supervises.
+type Configuration struct {
+	OpAMPServer *OpAMPServer `koanf:"server"`
+
+	AgentSettings *agent.Settings `koanf:"agent"`
+
+	// WatchConfig describes the configuration that is used to monitor the
+	// health of the agent.
+	WatchConfig *agent.WatchConfig `kaonf:"watchdog"`
+}
+
+// Load the supervisor configuration.
+func (s *supervisor) loadConfig() (*Configuration, error) {
+	k := koanf.New(".")
+	if err := k.Load(file.Provider(s.configFile), yaml.Parser()); err != nil {
+		return nil, fmt.Errorf("failed to read supervisor configuration: %w", err)
+	}
+
+	var config Configuration
+	if err := k.Unmarshal("", &config); err != nil {
+		return nil, fmt.Errorf("failed to parse supervisor configuration: %w", err)
+	}
+
+	if s.config.OpAMPServer == nil {
+		return nil, errors.New("'server' section missing")
+	}
+
+	if s.config.AgentSettings == nil {
+		return nil, errors.New("'agent' section missing")
+	}
+
+	if s.config.OpAMPServer.TLSConfig != nil {
+		tc, err := s.config.OpAMPServer.TLSConfig.loadTLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load TLS configuration: %w", err)
+		}
+		s.tls = tc
+	}
+
+	return &config, nil
+}

--- a/supervisor/internal/examples/config_sample.yaml
+++ b/supervisor/internal/examples/config_sample.yaml
@@ -1,0 +1,78 @@
+# Connection details for the OpAMP server.
+server:
+    endpoint: wss://localhost:1729
+    #    tls:
+    # Client-side TLS configuration to connect to the OpAMP server.
+
+# Watchdog allows the supervisor to monitor the health of the agent and ensure
+# it is always running (restarting if necessary). In this sense, it acts as
+# an alternative to agent installations that are not managed by systemd.
+#
+# A watchdog policy, like `systemd', albeit not as exhaustive, allows the
+# watchdog to honor certain timing restrictions during the start, stop and
+# restart of the agents.
+watchdog:
+    # Command describes how the agent must be exec'd.
+    command:
+        # Full or relative path to the agent executable.
+        name: /opt/otcol/bin/otel
+        # Set of command-line arguments required to start the `executable`
+        # specified above.
+        args:
+            - --config
+            - /etc/otcol/config.yaml
+
+    # Dictates how to check if the agent is healthy.
+    health_check:
+        url: http://localhost:13133/
+        initial_delay: 5s
+        period: 5s
+        timeout: 1s
+        success_threshold: 1
+        failure_threshold: 3
+
+    # Max attempts the agent is allowed to fail when attempted to START or
+    # STOP in which case the operation will be re-attempted.
+    max_attempts: 3
+
+    # Duration to wait between successive attempts of a START or STOP.
+    wait_between_attempts: 1s
+
+agent:
+    # Set of capabilities that this agent supports.
+    capabilities:
+        - REPORTS_CONFIG
+        - ACCEPTS_CONFIG
+        - REPORTS_PACKAGE
+        - ACCEPTS_PACAKGE
+        # - REPORTS_ADDONS
+        # - ACCEPTS_ADDONS
+        # - REPORTS_OWN_TRACES
+        # - REPORTS_OWN_METRICS
+        # - REPORTS_OWN_LOGS
+        # - ACCEPTS_OPAMP_CONN_SETTINGS
+        # - ACCEPTS_OTHER_CONN_SETTINGS
+
+    # An arbitrary set of key-value pairs that identify this agent and may
+    # describe where this agent runs.
+    attrs:
+        -   service.name: io.opentelemetry.collector
+        -   service.namespace: collector
+        -   other_attr1: other_attr1_val
+        -   other_attr2: other_attr2_val
+
+    # Describes the configuration properties of the agent. This field MUST
+    # be specified if `REPORTS_CONFIG' or `ACCEPTS_CONFIG' capabilities are set.
+    config:
+        # Currently, only a `file' based configuration is accepted.
+        file: /opt/opentelemetry-collector/config.yaml
+        # If `auto_reload` is true, then the agent doesn't need a restart on a config
+        # change as it is internally managed by the agent.
+        auto_reload: false
+
+    # Describes the set of files that makes up the agent and therefore allows
+    # the agent to be updated. This field MUST be specified if `REPORTS_PACKAGE'
+    # or `ACCEPTS_PACKAGE' capabilities are turned on.
+    package:
+        files:
+            -   otel: /opt/otcol/bin/otel

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -117,7 +117,7 @@ func (s *supervisor) Start() error {
 		s.logger.Debugf("Failed to stop the client: %v", err)
 	}
 	if err := s.watcher.Shutdown(ctx); err != nil {
-		s.logger.Debugf("Failed to stop the watcher: %w", err)
+		s.logger.Debugf("Failed to stop the watcher: %v", err)
 	}
 
 	return nil

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -1,0 +1,124 @@
+package supervisor
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/oklog/ulid/v2"
+	"github.com/open-telemetry/opamp-go/client"
+	"github.com/open-telemetry/opamp-go/supervisor/agent"
+	"log"
+	"math/rand"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+type Logger struct {
+	Logger *log.Logger
+}
+
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	l.Logger.Printf(format, v...)
+}
+
+func (l *Logger) Errorf(format string, v ...interface{}) {
+	l.Logger.Printf(format, v...)
+}
+
+type supervisor struct {
+	logger *Logger
+
+	configFile string
+	config     *Configuration
+	tls        *tls.Config
+
+	instanceID string
+
+	client client.OpAMPClient
+
+	agentSettings *agent.Settings
+	agent         agent.Agent
+	watcher       agent.Watcher
+	configurer    agent.Configurer
+	packager      agent.Packager
+}
+
+// New creates a new supervisor based on the provided configuration.
+func New(configFile string, logger *Logger) *supervisor {
+	entropy := ulid.Monotonic(rand.New(rand.NewSource(0)), 0)
+	return &supervisor{
+		configFile: configFile,
+		client:     client.New(logger),
+		instanceID: ulid.MustNew(ulid.Timestamp(time.Now()), entropy).String(),
+	}
+}
+
+func (s *supervisor) createAgent() error {
+	panic("implement me")
+}
+
+func (s *supervisor) createAndStartAgent(ctx context.Context) error {
+	if err := s.createAgent(); err != nil {
+		return fmt.Errorf("failed to create an agent from the specified configuration: %w", err)
+	}
+
+	if err := s.watcher.Watch(ctx); err != nil {
+		return fmt.Errorf("failed to start the watchdog: %w", err)
+	}
+
+	return nil
+}
+
+func (s *supervisor) createAndStartClient() error {
+	settings := client.StartSettings{
+		OpAMPServerURL: s.config.OpAMPServer.Endpoint,
+		TLSConfig:      s.tls,
+		InstanceUid:    s.instanceID,
+		Callbacks:      s,
+	}
+
+	if s.configurer != nil {
+		effectiveConfig, err := s.configurer.LoadEffectiveConfig(s.agentSettings.ConfigSpec)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve agent's effective config: %w", err)
+		}
+		settings.LastEffectiveConfig = effectiveConfig
+	}
+
+	return s.client.Start(settings)
+}
+
+func (s *supervisor) Start() error {
+	// Load the supervisor configuration.
+	config, err := s.loadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load supervisor configuration: %w", err)
+	}
+	s.config = config
+
+	ctx := context.Background()
+
+	if err := s.createAndStartAgent(ctx); err != nil {
+		return fmt.Errorf("failed to start the agent: %w", err)
+	}
+
+	if err := s.createAndStartClient(); err != nil {
+		return fmt.Errorf("failed to start the client: %w", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-sigCh
+	s.logger.Debugf("Received termination signal: %s", sig)
+
+	if err := s.client.Stop(ctx); err != nil {
+		s.logger.Debugf("Failed to stop the client: %v", err)
+	}
+	if err := s.watcher.Shutdown(ctx); err != nil {
+		s.logger.Debugf("Failed to stop the watcher: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This changeset describes several interface that an agent must implement
in order to fit itself in the supervisor model.

The basic idea is that:

1. We implement several of these interfaces as part of the reference
implementation.

2. Many of those default implementations may work with most agents but
some might be tailored fro OT Collector.

3. Custom OT collectors or other custom agents may change the
implementations. As long as the interfaces are honored, the rest of the
supervisor should work.