### PR TITLE
Avoid sending status update if the effective config is unchanged

### DIFF
--- a/client/callbacks.go
+++ b/client/callbacks.go
@@ -14,8 +14,8 @@ type CallbacksStruct struct {
 
 	OnRemoteConfigFunc func(
 		ctx context.Context,
-		config *protobufs.AgentRemoteConfig,
-	) (*protobufs.EffectiveConfig, error)
+		remoteConfig *protobufs.AgentRemoteConfig,
+	) (effectiveConfig *protobufs.EffectiveConfig, configChanged bool, err error)
 
 	OnOpampConnectionSettingsFunc func(
 		ctx context.Context,
@@ -62,12 +62,13 @@ func (c CallbacksStruct) OnError(err *protobufs.ServerErrorResponse) {
 }
 
 func (c CallbacksStruct) OnRemoteConfig(
-	ctx context.Context, remoteConfig *protobufs.AgentRemoteConfig,
-) (*protobufs.EffectiveConfig, error) {
+	ctx context.Context,
+	remoteConfig *protobufs.AgentRemoteConfig,
+) (effectiveConfig *protobufs.EffectiveConfig, configChanged bool, err error) {
 	if c.OnRemoteConfigFunc != nil {
 		return c.OnRemoteConfigFunc(ctx, remoteConfig)
 	}
-	return nil, nil
+	return nil, false, nil
 }
 
 func (c CallbacksStruct) OnOpampConnectionSettings(

--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -271,15 +271,16 @@ func TestFirstStatusReport(t *testing.T) {
 				atomic.AddInt64(&connected, 1)
 			},
 			OnRemoteConfigFunc: func(
-				ctx context.Context, config *protobufs.AgentRemoteConfig,
-			) (*protobufs.EffectiveConfig, error) {
+				ctx context.Context,
+				config *protobufs.AgentRemoteConfig,
+			) (effectiveConfig *protobufs.EffectiveConfig, configChanged bool, err error) {
 				// Verify that the client received exactly the remote config that
 				// the server sent.
 				assert.True(t, proto.Equal(remoteConfig, config))
 				atomic.AddInt64(&remoteConfigReceived, 1)
 				return &protobufs.EffectiveConfig{
 					ConfigMap: remoteConfig.Config,
-				}, nil
+				}, true, nil
 			},
 		},
 		AgentDescription: &protobufs.AgentDescription{},

--- a/client/types/callbacks.go
+++ b/client/types/callbacks.go
@@ -35,6 +35,10 @@ type Callbacks interface {
 	//
 	// The Agent should process the config and return the effective config if processing
 	// succeeded or an error if processing failed.
+	//
+	// configChanged must be set to true if as a result of applying the remote config
+	// the effective config has changed.
+	//
 	// The returned effective config or the error will be reported back to the server
 	// via StatusReport message (using EffectiveConfig and RemoteConfigStatus fields).
 	//
@@ -45,8 +49,8 @@ type Callbacks interface {
 	// remote config received.
 	OnRemoteConfig(
 		ctx context.Context,
-		config *protobufs.AgentRemoteConfig,
-	) (*protobufs.EffectiveConfig, error)
+		remoteConfig *protobufs.AgentRemoteConfig,
+	) (effectiveConfig *protobufs.EffectiveConfig, configChanged bool, err error)
 
 	// OnOpampConnectionSettings is called when the agent receives an OpAMP
 	// connection settings offer from the server. Typically the settings can specify


### PR DESCRIPTION
This change implements the following OpAMP Spec requirement
https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#status-reporting:

When the Agent receives a ServerToAgent message the Agent MUST NOT
send a status report unless processing of the message received from
the Server resulted in actual change of the Agent status (e.g. the
configuration of the Agent has changed).

Before this implementation the agent would unnecessarily send status
updates even though they were unnecessary since nothing was changed.