### PR TITLE
Expose the RemoteAddr and request Header via the Connection interface

### DIFF
--- a/server/connection.go
+++ b/server/connection.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"net"
+	"net/http"
 
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
@@ -12,9 +14,18 @@ import (
 
 type connection struct {
 	wsConn *websocket.Conn
+	header http.Header
 }
 
 var _ types.Connection = (*connection)(nil)
+
+func (c connection) RemoteAddr() net.Addr {
+	return c.RemoteAddr()
+}
+
+func (c connection) Header() http.Header {
+	return c.header
+}
 
 func (c connection) Send(ctx context.Context, message *protobufs.ServerToAgent) error {
 	bytes, err := proto.Marshal(message)

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -151,12 +151,12 @@ func (s *server) httpHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Return from this func to reduce memory usage.
-	// Handle the connection on a separate gorountine.
-	go s.handleWSConnection(conn)
+	// Handle the connection on a separate goroutine.
+	go s.handleWSConnection(conn, req.Header)
 }
 
-func (s *server) handleWSConnection(wsConn *websocket.Conn) {
-	agentConn := connection{wsConn: wsConn}
+func (s *server) handleWSConnection(wsConn *websocket.Conn, reqHeader http.Header) {
+	agentConn := connection{wsConn: wsConn, header: reqHeader}
 
 	defer func() {
 		// Close the connection when all is done.

--- a/server/types/connection.go
+++ b/server/types/connection.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"context"
+	"net"
+	"net/http"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
@@ -9,6 +11,12 @@ import (
 // Connection represents one OpAMP WebSocket connections.
 // The implementation MUST be a comparable type so that it can be used as a map key.
 type Connection interface {
+	// RemoteAddr returns the remote network address of the connection.
+	RemoteAddr() net.Addr
+
+	// Header returns the request header fields of the http request that opened the connection.
+	Header() http.Header
+
 	// Send a message. Should not be called concurrently for the same Connection instance.
 	// Blocks until the message is sent.
 	// Should return as soon as possible if the ctx is cancelled.


### PR DESCRIPTION
This was originally proposed in a slack message in the CNCF otel-agentmanwg channel.
