### PR TITLE
Implement plain HTTP Transport in OpAMPServer

### DIFF
--- a/internal/examples/server/opampsrv/opampsrv.go
+++ b/internal/examples/server/opampsrv/opampsrv.go
@@ -53,7 +53,7 @@ func (srv *Server) onDisconnect(conn types.Connection) {
 	srv.agents.RemoveConnection(conn)
 }
 
-func (srv *Server) onMessage(conn types.Connection, msg *protobufs.AgentToServer) {
+func (srv *Server) onMessage(conn types.Connection, msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 	instanceId := data.InstanceId(msg.InstanceUid)
 
 	agent := srv.agents.FindOrCreateAgent(instanceId, conn)
@@ -69,5 +69,5 @@ func (srv *Server) onMessage(conn types.Connection, msg *protobufs.AgentToServer
 	}
 
 	// Send the response back to the agent.
-	agent.SendToAgent(response)
+	return response
 }

--- a/server/callbacks.go
+++ b/server/callbacks.go
@@ -10,7 +10,7 @@ import (
 type CallbacksStruct struct {
 	OnConnectingFunc      func(request *http.Request) types.ConnectionResponse
 	OnConnectedFunc       func(conn types.Connection)
-	OnMessageFunc         func(conn types.Connection, message *protobufs.AgentToServer)
+	OnMessageFunc         func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent
 	OnConnectionCloseFunc func(conn types.Connection)
 }
 
@@ -29,9 +29,14 @@ func (c CallbacksStruct) OnConnected(conn types.Connection) {
 	}
 }
 
-func (c CallbacksStruct) OnMessage(conn types.Connection, message *protobufs.AgentToServer) {
+func (c CallbacksStruct) OnMessage(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 	if c.OnMessageFunc != nil {
-		c.OnMessageFunc(conn, message)
+		return c.OnMessageFunc(conn, message)
+	} else {
+		// We will send an empty response since there is no user-defined callback to handle it.
+		return &protobufs.ServerToAgent{
+			InstanceUid: message.InstanceUid,
+		}
 	}
 }
 

--- a/server/httpconnection.go
+++ b/server/httpconnection.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/open-telemetry/opamp-go/server/types"
+)
+
+var errInvalidHTTPConnection = errors.New("cannot Send() over HTTP connection")
+
+// httpConnection represents an OpAMP connection over a plain HTTP connection.
+// Only one response is possible to send when using plain HTTP connection
+// and that response will be sent by OpAMP server's HTTP request handler after the
+// onMessage callback returns.
+type httpConnection struct {
+	conn net.Conn
+}
+
+func (c httpConnection) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+var _ types.Connection = (*httpConnection)(nil)
+
+func (c httpConnection) Send(_ context.Context, _ *protobufs.ServerToAgent) error {
+	// Send() should not be called for plain HTTP connection. Instead, the response will
+	// be sent after the onMessage callback returns.
+	return errInvalidHTTPConnection
+}

--- a/server/httpconnectioncontext.go
+++ b/server/httpconnectioncontext.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+)
+
+type connContextKeyType struct {
+	key string
+}
+
+var connContextKey = connContextKeyType{key: "httpconn"}
+
+func contextWithConn(ctx context.Context, c net.Conn) context.Context {
+	// Create a new context that stores the net.Conn. For use as ConnContext func
+	// of http.Server to remember the connection in the context.
+	return context.WithValue(ctx, connContextKey, c)
+}
+func connFromRequest(r *http.Request) net.Conn {
+	// Extract the net.Conn from the context of the specified http.Request.
+	return r.Context().Value(connContextKey).(net.Conn)
+}

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -130,7 +132,7 @@ func TestServerReceiveSendMessage(t *testing.T) {
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true}
 		},
-		OnMessageFunc: func(conn types.Connection, message *protobufs.AgentToServer) {
+		OnMessageFunc: func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			// Remember received message.
 			rcvMsg.Store(message)
 
@@ -139,8 +141,7 @@ func TestServerReceiveSendMessage(t *testing.T) {
 				InstanceUid:  message.InstanceUid,
 				Capabilities: protobufs.ServerCapabilities_AcceptsStatus,
 			}
-			err := conn.Send(context.Background(), &response)
-			assert.NoError(t, err)
+			return &response
 		},
 	}
 
@@ -180,6 +181,72 @@ func TestServerReceiveSendMessage(t *testing.T) {
 	// Verify the response.
 	assert.EqualValues(t, sendMsg.InstanceUid, response.InstanceUid)
 	assert.EqualValues(t, protobufs.ServerCapabilities_AcceptsStatus, response.Capabilities)
+}
+
+func TestServerReceiveSendMessagePlainHTTP(t *testing.T) {
+	var rcvMsg atomic.Value
+	var onConnectedCalled, onCloseCalled int32
+	callbacks := CallbacksStruct{
+		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
+			return types.ConnectionResponse{Accept: true}
+		},
+		OnConnectedFunc: func(conn types.Connection) {
+			atomic.StoreInt32(&onConnectedCalled, 1)
+		},
+		OnMessageFunc: func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			// Remember received message.
+			rcvMsg.Store(message)
+
+			// Send a response.
+			response := protobufs.ServerToAgent{
+				InstanceUid:  message.InstanceUid,
+				Capabilities: protobufs.ServerCapabilities_AcceptsStatus,
+			}
+			return &response
+		},
+		OnConnectionCloseFunc: func(conn types.Connection) {
+			atomic.StoreInt32(&onCloseCalled, 1)
+		},
+	}
+
+	// Start a server.
+	settings := &StartSettings{Settings: Settings{Callbacks: callbacks}}
+	srv := startServer(t, settings)
+	defer srv.Stop(context.Background())
+
+	// Send a message to the server.
+	sendMsg := protobufs.AgentToServer{
+		InstanceUid: "12345678",
+	}
+	b, err := proto.Marshal(&sendMsg)
+	require.NoError(t, err)
+	resp, err := http.Post("http://"+settings.ListenEndpoint+settings.ListenPath, contentTypeProtobuf, bytes.NewReader(b))
+	require.NoError(t, err)
+
+	// Wait until server receives the message.
+	eventually(t, func() bool { return rcvMsg.Load() != nil })
+	assert.True(t, atomic.LoadInt32(&onConnectedCalled) == 1)
+
+	// Verify the received message is what was sent.
+	assert.True(t, proto.Equal(rcvMsg.Load().(proto.Message), &sendMsg))
+
+	// Read server's response.
+	b, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, http.StatusOK, resp.StatusCode)
+	assert.EqualValues(t, contentTypeProtobuf, resp.Header.Get(headerContentType))
+
+	// Decode the response.
+	var response protobufs.ServerToAgent
+	err = proto.Unmarshal(b, &response)
+	require.NoError(t, err)
+
+	// Verify the response.
+	assert.EqualValues(t, sendMsg.InstanceUid, response.InstanceUid)
+	assert.EqualValues(t, protobufs.ServerCapabilities_AcceptsStatus, response.Capabilities)
+
+	eventually(t, func() bool { return atomic.LoadInt32(&onCloseCalled) == 1 })
 }
 
 func TestServerAttachAcceptConnection(t *testing.T) {

--- a/server/types/callbacks.go
+++ b/server/types/callbacks.go
@@ -29,16 +29,17 @@ type Callbacks interface {
 	//   HTTPResponseHeader may be optionally set (e.g. "Retry-After: 30").
 	OnConnecting(request *http.Request) ConnectionResponse
 
-	// OnConnected is called when the WebSocket connection is successfully established
-	// after OnConnecting() returns and the HTTP connection is upgraded to WebSocket.
+	// OnConnected is called when and incoming OpAMP connection is successfully
+	// established after OnConnecting() returns.
 	OnConnected(conn Connection)
 
 	// OnMessage is called when a message is received from the connection. Can happen
-	// only after OnConnected().
-	OnMessage(conn Connection, message *protobufs.AgentToServer)
+	// only after OnConnected(). Must return a ServerToAgent message that will be sent
+	// as a response to the agent.
+	// For plain HTTP requests once OnMessage returns and the response is sent
+	// to the agent the OnConnectionClose message will be called immediately.
+	OnMessage(conn Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent
 
-	// OnConnectionClose is called when the WebSocket connection is closed.
-	// Typically, preceded by OnDisconnect() unless the client misbehaves or the
-	// connection is lost.
+	// OnConnectionClose is called when the OpAMP connection is closed.
 	OnConnectionClose(conn Connection)
 }

--- a/server/types/connection.go
+++ b/server/types/connection.go
@@ -7,13 +7,15 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
-// Connection represents one OpAMP WebSocket connections.
+// Connection represents one OpAMP connection.
 // The implementation MUST be a comparable type so that it can be used as a map key.
 type Connection interface {
 	// RemoteAddr returns the remote network address of the connection.
 	RemoteAddr() net.Addr
 
 	// Send a message. Should not be called concurrently for the same Connection instance.
+	// Can be called only for WebSocket connections. Will return an error for plain HTTP
+	// connections.
 	// Blocks until the message is sent.
 	// Should return as soon as possible if the ctx is cancelled.
 	Send(ctx context.Context, message *protobufs.ServerToAgent) error

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -11,17 +11,18 @@ import (
 	"github.com/open-telemetry/opamp-go/server/types"
 )
 
-type connection struct {
+// wsConnection represents a persistent OpAMP connection over a WebSocket.
+type wsConnection struct {
 	wsConn *websocket.Conn
 }
 
-var _ types.Connection = (*connection)(nil)
+var _ types.Connection = (*wsConnection)(nil)
 
-func (c connection) RemoteAddr() net.Addr {
+func (c wsConnection) RemoteAddr() net.Addr {
 	return c.wsConn.RemoteAddr()
 }
 
-func (c connection) Send(ctx context.Context, message *protobufs.ServerToAgent) error {
+func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) error {
 	bytes, err := proto.Marshal(message)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds plain HTTP request support to OpAMPServer implementation.
Implements spec change: https://github.com/open-telemetry/opamp-spec/pull/70