### PR TITLE
Ensure client includes AgentDescription on Reconnect

### DIFF
--- a/client/clientimpl.go
+++ b/client/clientimpl.go
@@ -152,6 +152,9 @@ func (w *client) SetAgentDescription(descr *protobufs.AgentDescription) error {
 		return errAgentDescriptionMissing
 	}
 
+	// store the agent description to send on reconnect
+	w.settings.AgentDescription = descr
+
 	w.sender.UpdateNextStatus(func(statusReport *protobufs.StatusReport) {
 		statusReport.AgentDescription = descr
 	})

--- a/client/clientimpl.go
+++ b/client/clientimpl.go
@@ -106,22 +106,6 @@ func (w *client) Start(settings StartSettings) error {
 		w.requestHeader["Authorization"] = []string{w.settings.AuthorizationHeader}
 	}
 
-	// Prepare the first status report.
-	w.sender.UpdateNextStatus(
-		func(statusReport *protobufs.StatusReport) {
-			statusReport.AgentDescription = w.settings.AgentDescription
-		},
-	)
-
-	w.sender.UpdateNextMessage(
-		func(msg *protobufs.AgentToServer) {
-			if msg.AddonStatuses == nil {
-				msg.AddonStatuses = &protobufs.AgentAddonStatuses{}
-			}
-			msg.AddonStatuses.ServerProvidedAllAddonsHash = w.settings.LastServerProvidedAllAddonsHash
-		},
-	)
-
 	w.startConnectAndRun()
 
 	w.isStarted = true
@@ -324,6 +308,22 @@ func (w *client) runOneCycle(ctx context.Context) {
 
 	// Create a cancellable context for background processors.
 	procCtx, procCancel := context.WithCancel(ctx)
+
+	// Prepare the first status report.
+	w.sender.UpdateNextStatus(
+		func(statusReport *protobufs.StatusReport) {
+			statusReport.AgentDescription = w.settings.AgentDescription
+		},
+	)
+
+	w.sender.UpdateNextMessage(
+		func(msg *protobufs.AgentToServer) {
+			if msg.AddonStatuses == nil {
+				msg.AddonStatuses = &protobufs.AgentAddonStatuses{}
+			}
+			msg.AddonStatuses.ServerProvidedAllAddonsHash = w.settings.LastServerProvidedAllAddonsHash
+		},
+	)
 
 	// Connected successfully. Start the sender. This will also send the first
 	// status report.


### PR DESCRIPTION
Resolves: https://github.com/open-telemetry/opamp-go/issues/55

This PR ensures that the client includes AgentDescription every time it connects to the server, not just after `client.Start`.

Current behavior:
- Clients connection to server is interrupted.
- Client reconnects.
- Client does not prepare a "first status message" with an `AgentDescription`.

Expected behavior:
- Clients connection to server is interrupted.
- Client reconnects.
- Client prepares and sends a status including AgentDescription.
