### PR TITLE
Eliminate StartSettings.AgentDescription

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -43,13 +43,15 @@ type OpAMPClient interface {
 	Stop(ctx context.Context) error
 
 	// SetAgentDescription sets attributes of the Agent. The attributes will be included
-	// in the next status report sent to the Server.
-	// May be called after Start(), in which case the attributes will be included
+	// in the next status report sent to the Server. MUST be called before Start().
+	// May be also called after Start(), in which case the attributes will be included
 	// in the next outgoing status report. This is typically used by Agents which allow
 	// their AgentDescription to change dynamically while the OpAMPClient is started.
-	// To define the initial Agent description that is included in the first status report
-	// set StartSettings.AgentDescription field.
+	// nil values are not allowed and will return an error.
 	SetAgentDescription(descr *protobufs.AgentDescription) error
+
+	// AgentDescription returns the last value successfully set by SetAgentDescription().
+	AgentDescription() *protobufs.AgentDescription
 
 	// UpdateEffectiveConfig fetches the current local effective config using
 	// GetEffectiveConfig callback and sends it to the Server.

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -62,6 +62,10 @@ func (c *httpClient) Stop(ctx context.Context) error {
 	return c.common.Stop(ctx)
 }
 
+func (c *httpClient) AgentDescription() *protobufs.AgentDescription {
+	return c.common.AgentDescription()
+}
+
 func (c *httpClient) SetAgentDescription(descr *protobufs.AgentDescription) error {
 	return c.common.SetAgentDescription(descr)
 }

--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	errAgentDescriptionMissing   = errors.New("AgentDescription is not set")
-	errRemoteConfigStatusMissing = errors.New("RemoteConfigStatus is not set")
-	errAlreadyStarted            = errors.New("already started")
-	errCannotStopNotStarted      = errors.New("cannot stop because not started")
+	ErrAgentDescriptionMissing      = errors.New("AgentDescription is nil")
+	ErrAgentDescriptionNoAttributes = errors.New("AgentDescription has no attributes defined")
+	errRemoteConfigStatusMissing    = errors.New("RemoteConfigStatus is not set")
+	errAlreadyStarted               = errors.New("already started")
+	errCannotStopNotStarted         = errors.New("cannot stop because not started")
 )
 
 // ClientCommon contains the OpAMP logic that is common between WebSocket and
@@ -52,8 +53,8 @@ func (c *ClientCommon) PrepareStart(_ context.Context, settings types.StartSetti
 		return errAlreadyStarted
 	}
 
-	if err := c.ClientSyncedState.SetAgentDescription(settings.AgentDescription); err != nil {
-		return err
+	if c.ClientSyncedState.AgentDescription() == nil {
+		return ErrAgentDescriptionMissing
 	}
 
 	if settings.RemoteConfigStatus == nil {
@@ -166,6 +167,10 @@ func (c *ClientCommon) PrepareFirstMessage(ctx context.Context) error {
 		},
 	)
 	return nil
+}
+
+func (c *ClientCommon) AgentDescription() *protobufs.AgentDescription {
+	return c.ClientSyncedState.AgentDescription()
 }
 
 // SetAgentDescription sends a status update to the Server with the new AgentDescription

--- a/client/internal/clientstate.go
+++ b/client/internal/clientstate.go
@@ -53,7 +53,11 @@ func (s *ClientSyncedState) PackageStatuses() *protobufs.PackageStatuses {
 // SetAgentDescription sets the AgentDescription in the state.
 func (s *ClientSyncedState) SetAgentDescription(descr *protobufs.AgentDescription) error {
 	if descr == nil {
-		return errAgentDescriptionMissing
+		return ErrAgentDescriptionMissing
+	}
+
+	if descr.IdentifyingAttributes == nil && descr.NonIdentifyingAttributes == nil {
+		return ErrAgentDescriptionNoAttributes
 	}
 
 	clone := proto.Clone(descr).(*protobufs.AgentDescription)

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -21,10 +21,6 @@ type StartSettings struct {
 	// Agent information.
 	InstanceUid string
 
-	// AgentDescription MUST be set and MUST describe the Agent. See OpAMP spec
-	// for details.
-	AgentDescription *protobufs.AgentDescription
-
 	// Callbacks that the client will call after Start() returns nil.
 	Callbacks Callbacks
 

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -92,6 +92,10 @@ func (c *wsClient) Stop(ctx context.Context) error {
 	return c.common.Stop(ctx)
 }
 
+func (c *wsClient) AgentDescription() *protobufs.AgentDescription {
+	return c.common.AgentDescription()
+}
+
 func (c *wsClient) SetAgentDescription(descr *protobufs.AgentDescription) error {
 	return c.common.SetAgentDescription(descr)
 }

--- a/internal/examples/agent/agent/agent.go
+++ b/internal/examples/agent/agent/agent.go
@@ -84,9 +84,8 @@ func (agent *Agent) start() error {
 	agent.opampClient = client.NewWebSocket(agent.logger)
 
 	settings := types.StartSettings{
-		OpAMPServerURL:   "ws://127.0.0.1:4320/v1/opamp",
-		InstanceUid:      agent.instanceId.String(),
-		AgentDescription: agent.agentDescription,
+		OpAMPServerURL: "ws://127.0.0.1:4320/v1/opamp",
+		InstanceUid:    agent.instanceId.String(),
 		Callbacks: types.CallbacksStruct{
 			OnConnectFunc: func() {
 				agent.logger.Debugf("Connected to the server.")
@@ -109,10 +108,14 @@ func (agent *Agent) start() error {
 		},
 		RemoteConfigStatus: agent.remoteConfigStatus,
 	}
+	err := agent.opampClient.SetAgentDescription(agent.agentDescription)
+	if err != nil {
+		return err
+	}
 
 	agent.logger.Debugf("Starting OpAMP client...")
 
-	err := agent.opampClient.Start(context.Background(), settings)
+	err = agent.opampClient.Start(context.Background(), settings)
 	if err != nil {
 		return err
 	}

--- a/internal/examples/server/data/agent.go
+++ b/internal/examples/server/data/agent.go
@@ -110,13 +110,18 @@ func (agent *Agent) updateStatusField(newStatus *protobufs.StatusReport) (agentD
 			// (or this is the first report).
 			// Make full comparison of previous and new descriptions to see if it
 			// really is different.
-			if prevStatus != nil && isEqualAgentDescr(prevStatus.AgentDescription, newStatus.AgentDescription) {
+			if prevStatus != nil && bytes.Equal(prevStatus.AgentDescription.Hash, newStatus.AgentDescription.Hash) {
 				// Agent description didn't change.
 				agentDescrChanged = false
 			} else {
 				// Yes, the description is different, update it.
-				agent.Status.AgentDescription = newStatus.AgentDescription
-				agentDescrChanged = true
+				if newStatus.AgentDescription.IdentifyingAttributes == nil &&
+					newStatus.AgentDescription.NonIdentifyingAttributes == nil {
+					// TODO: request full AgentDescription
+				} else {
+					agent.Status.AgentDescription = newStatus.AgentDescription
+					agentDescrChanged = true
+				}
 			}
 		} else {
 			// AgentDescription field is not set, which means description didn't change.


### PR DESCRIPTION
We don't need 2 ways to set AgentDescription, it is confusing.
Now the only way is to call SetAgentDescription(), which must be
called before Start() and may be called after Start() too.

Resolves https://github.com/open-telemetry/opamp-go/issues/47