### PR TITLE
Refactor OpAMPClient callbacks

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -47,6 +47,7 @@ type OpAMPClient interface {
 	// May be also called after Start(), in which case the attributes will be included
 	// in the next outgoing status report. This is typically used by Agents which allow
 	// their AgentDescription to change dynamically while the OpAMPClient is started.
+	// May be also called from OnMessage handler.
 	//
 	// The Hash field will be calculated and updated from the content of the rest of
 	// the fields.
@@ -59,5 +60,18 @@ type OpAMPClient interface {
 
 	// UpdateEffectiveConfig fetches the current local effective config using
 	// GetEffectiveConfig callback and sends it to the Server.
+	// May be called anytime after Start(), including from OnMessage handler.
 	UpdateEffectiveConfig(ctx context.Context) error
+
+	// SetRemoteConfigStatus sets the current RemoteConfigStatus.
+	// LastRemoteConfigHash field must be non-nil.
+	// May be called anytime after Start(), including from OnMessage handler.
+	// nil values are not allowed and will return an error.
+	SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error
+
+	// SetPackageStatuses sets the current PackageStatuses.
+	// ServerProvidedAllPackagesHash must be non-nil.
+	// May be called anytime after Start(), including from OnMessage handler.
+	// nil values are not allowed and will return an error.
+	SetPackageStatuses(statuses *protobufs.PackageStatuses) error
 }

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -72,6 +72,14 @@ func (c *httpClient) UpdateEffectiveConfig(ctx context.Context) error {
 	return c.common.UpdateEffectiveConfig(ctx)
 }
 
+func (c *httpClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error {
+	return c.common.SetRemoteConfigStatus(status)
+}
+
+func (c *httpClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
+	return c.common.SetPackageStatuses(statuses)
+}
+
 func (c *httpClient) runUntilStopped(ctx context.Context) {
 	// Start the HTTP sender. This will make request/responses with retries for
 	// failures and will wait with configured polling interval if there is nothing

--- a/client/internal/clientstate.go
+++ b/client/internal/clientstate.go
@@ -13,8 +13,10 @@ import (
 )
 
 var (
-	errRemoteConfigStatusMissing = errors.New("RemoteConfigStatus is not set")
-	errPackageStatusesMissing    = errors.New("PackageStatuses is not set")
+	errRemoteConfigStatusMissing        = errors.New("RemoteConfigStatus is not set")
+	errLastRemoteConfigHashNil          = errors.New("LastRemoteConfigHash is nil")
+	errPackageStatusesMissing           = errors.New("PackageStatuses is not set")
+	errServerProvidedAllPackagesHashNil = errors.New("ServerProvidedAllPackagesHash is nil")
 )
 
 // ClientSyncedState stores the state of the Agent messages that the OpAMP Client needs to

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -1,8 +1,8 @@
 package internal
 
 import (
-	"bytes"
 	"context"
+	"errors"
 
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -52,18 +52,43 @@ func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *pro
 			return
 		}
 
-		scheduled := r.rcvRemoteConfig(ctx, msg.RemoteConfig)
-
-		r.rcvConnectionSettings(ctx, msg.ConnectionSettings)
-		scheduled = scheduled || r.rcvPackagesAvailable(ctx, msg.PackagesAvailable)
-		r.rcvAgentIdentification(ctx, msg.AgentIdentification)
-
-		scheduled2, err := r.rcvFlags(ctx, msg.Flags)
+		scheduled, err := r.rcvFlags(ctx, msg.Flags)
 		if err != nil {
 			r.logger.Errorf("cannot processed received flags:%v", err)
 		}
 
-		scheduled = scheduled || scheduled2
+		msgData := &types.MessageData{
+			RemoteConfig: msg.RemoteConfig,
+		}
+
+		if msg.ConnectionSettings != nil {
+			msgData.OwnMetricsConnSettings = msg.ConnectionSettings.OwnMetrics
+			msgData.OwnTracesConnSettings = msg.ConnectionSettings.OwnTraces
+			msgData.OwnLogsConnSettings = msg.ConnectionSettings.OwnLogs
+			msgData.OtherConnSettings = msg.ConnectionSettings.OtherConnections
+		}
+
+		if msg.PackagesAvailable != nil {
+			msgData.PackagesAvailable = msg.PackagesAvailable
+			msgData.PackageSyncer = NewPackagesSyncer(
+				r.logger,
+				msgData.PackagesAvailable,
+				r.sender,
+				r.clientSyncedState,
+				r.packagesStateProvider,
+			)
+		}
+
+		if msg.AgentIdentification != nil {
+			err := r.rcvAgentIdentification(msg.AgentIdentification)
+			if err == nil {
+				msgData.AgentIdentification = msg.AgentIdentification
+			}
+		}
+
+		r.callbacks.OnMessage(ctx, msgData)
+
+		r.rcvOpampConnectionSettings(ctx, msg.ConnectionSettings)
 
 		if scheduled {
 			r.sender.ScheduleSend()
@@ -121,124 +146,15 @@ func (r *receivedProcessor) rcvFlags(
 	return scheduleSend, nil
 }
 
-func (r *receivedProcessor) rcvRemoteConfig(
-	ctx context.Context,
-	remoteCfg *protobufs.AgentRemoteConfig,
-) (reportStatus bool) {
-	if remoteCfg == nil {
-		return false
-	}
-
-	// Ask the Agent to apply the remote config.
-	effective, changed, applyErr := r.callbacks.OnRemoteConfig(ctx, remoteCfg)
-
-	// Begin creating the new status.
-	cfgStatus := &protobufs.RemoteConfigStatus{}
-
-	if applyErr != nil {
-		// Remote config applying failed.
-		cfgStatus.Status = protobufs.RemoteConfigStatus_FAILED
-		cfgStatus.ErrorMessage = applyErr.Error()
-	} else {
-		// Applied successfully.
-		cfgStatus.Status = protobufs.RemoteConfigStatus_APPLIED
-	}
-
-	// Respond back with the hash of the config received from the Server.
-	cfgStatus.LastRemoteConfigHash = remoteCfg.ConfigHash
-
-	// Get the hash of the status before we update it.
-	prevStatus := r.clientSyncedState.RemoteConfigStatus()
-	var prevCfgStatusHash []byte
-	if prevStatus != nil {
-		prevCfgStatusHash = prevStatus.Hash
-	}
-
-	// Remember the status for the future use.
-	_ = r.clientSyncedState.SetRemoteConfigStatus(cfgStatus)
-
-	// Check if the status has changed by comparing the hashes.
-	if !bytes.Equal(prevCfgStatusHash, cfgStatus.Hash) {
-		// Let the Agent know about the status.
-		r.callbacks.SaveRemoteConfigStatus(ctx, cfgStatus)
-
-		// Include the config status in the next message to the Server.
-		r.sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
-			msg.RemoteConfigStatus = cfgStatus
-		})
-
-		reportStatus = true
-	}
-
-	// Report the effective configuration if it changed and remote config was applied
-	// successfully.
-	if changed && applyErr == nil {
-		r.sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
-			msg.EffectiveConfig = effective
-		})
-		reportStatus = true
-	}
-	return reportStatus
-}
-
-func (r *receivedProcessor) rcvConnectionSettings(ctx context.Context, settings *protobufs.ConnectionSettingsOffers) {
-	if settings == nil {
+func (r *receivedProcessor) rcvOpampConnectionSettings(ctx context.Context, settings *protobufs.ConnectionSettingsOffers) {
+	if settings == nil || settings.Opamp == nil {
 		return
 	}
 
-	if settings.Opamp != nil {
-		err := r.callbacks.OnOpampConnectionSettings(ctx, settings.Opamp)
-		if err == nil {
-			// TODO: verify connection using new settings.
-			r.callbacks.OnOpampConnectionSettingsAccepted(settings.Opamp)
-		}
-	}
-
-	r.rcvOwnTelemetryConnectionSettings(
-		ctx,
-		settings.OwnMetrics,
-		types.OwnMetrics,
-		r.callbacks.OnOwnTelemetryConnectionSettings,
-	)
-
-	r.rcvOwnTelemetryConnectionSettings(
-		ctx,
-		settings.OwnTraces,
-		types.OwnTraces,
-		r.callbacks.OnOwnTelemetryConnectionSettings,
-	)
-
-	r.rcvOwnTelemetryConnectionSettings(
-		ctx,
-		settings.OwnLogs,
-		types.OwnLogs,
-		r.callbacks.OnOwnTelemetryConnectionSettings,
-	)
-
-	for name, s := range settings.OtherConnections {
-		r.rcvOtherConnectionSettings(ctx, s, name, r.callbacks.OnOtherConnectionSettings)
-	}
-}
-
-func (r *receivedProcessor) rcvOwnTelemetryConnectionSettings(
-	ctx context.Context,
-	settings *protobufs.TelemetryConnectionSettings,
-	telemetryType types.OwnTelemetryType,
-	callback func(ctx context.Context, telemetryType types.OwnTelemetryType, settings *protobufs.TelemetryConnectionSettings) error,
-) {
-	if settings != nil {
-		callback(ctx, telemetryType, settings)
-	}
-}
-
-func (r *receivedProcessor) rcvOtherConnectionSettings(
-	ctx context.Context,
-	settings *protobufs.OtherConnectionSettings,
-	name string,
-	callback func(ctx context.Context, name string, settings *protobufs.OtherConnectionSettings) error,
-) {
-	if settings != nil {
-		callback(ctx, name, settings)
+	err := r.callbacks.OnOpampConnectionSettings(ctx, settings.Opamp)
+	if err == nil {
+		// TODO: verify connection using new settings.
+		r.callbacks.OnOpampConnectionSettingsAccepted(settings.Opamp)
 	}
 }
 
@@ -247,65 +163,20 @@ func (r *receivedProcessor) processErrorResponse(body *protobufs.ServerErrorResp
 	r.logger.Errorf("received an error from server: %s", body.ErrorMessage)
 }
 
-func (r *receivedProcessor) rcvPackagesAvailable(ctx context.Context, available *protobufs.PackagesAvailable) bool {
-	if available == nil {
-		return false
-	}
-
-	syncer := NewPackagesSyncer(r.logger, available, r.sender, r.clientSyncedState, r.packagesStateProvider)
-
-	// The OnPackagesAvailable is expected to call syncer.Sync() which will
-	// do the syncing process in background.
-	err := r.callbacks.OnPackagesAvailable(ctx, available, syncer)
-	if err != nil {
-		// Could not even start syncing. Just report everything failed.
-		statuses := &protobufs.PackageStatuses{
-			ServerProvidedAllPackagesHash: available.AllPackagesHash,
-			Packages:                      map[string]*protobufs.PackageStatus{},
-			// TODO: we need a way to report general errors that occurred when trying
-			// install available packages, errors which are not related to a particular
-			// package.
-		}
-		// Until the TODO above is done we will set the same error message for all
-		// packages.
-		for name, pkg := range available.Packages {
-			statuses.Packages[name] = &protobufs.PackageStatus{
-				Name:                 name,
-				ServerOfferedVersion: pkg.Version,
-				ServerOfferedHash:    pkg.Hash,
-				Status:               protobufs.PackageStatus_InstallFailed,
-				ErrorMessage:         err.Error(),
-			}
-		}
-		_ = r.clientSyncedState.SetPackageStatuses(statuses)
-		r.sender.NextMessage().Update(
-			func(msg *protobufs.AgentToServer) { msg.PackageStatuses = statuses },
-		)
-	}
-
-	return true
-}
-
-func (r *receivedProcessor) rcvAgentIdentification(ctx context.Context, agentId *protobufs.AgentIdentification) {
-	if agentId == nil {
-		return
-	}
-
+func (r *receivedProcessor) rcvAgentIdentification(agentId *protobufs.AgentIdentification) error {
 	if agentId.NewInstanceUid == "" {
-		r.logger.Debugf("Empty instance uid is not allowed")
-		return
+		err := errors.New("empty instance uid is not allowed")
+		r.logger.Debugf(err.Error())
+		return err
 	}
 
-	err := r.callbacks.OnAgentIdentification(ctx, agentId)
-	if err != nil {
-		r.logger.Errorf("Error while updating agent identification: %v", err)
-		return
-	}
-
-	err = r.sender.SetInstanceUid(agentId.NewInstanceUid)
+	err := r.sender.SetInstanceUid(agentId.NewInstanceUid)
 	if err != nil {
 		r.logger.Errorf("Error while setting instance uid: %v, err")
+		return err
 	}
+
+	return nil
 }
 
 func (r *receivedProcessor) rcvCommand(command *protobufs.ServerToAgentCommand) {

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -101,6 +101,14 @@ func (c *wsClient) UpdateEffectiveConfig(ctx context.Context) error {
 	return c.common.UpdateEffectiveConfig(ctx)
 }
 
+func (c *wsClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error {
+	return c.common.SetRemoteConfigStatus(status)
+}
+
+func (c *wsClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
+	return c.common.SetPackageStatuses(statuses)
+}
+
 // Try to connect once. Returns an error if connection fails and optional retryAfter
 // duration to indicate to the caller to retry after the specified time as instructed
 // by the Server.

--- a/internal/proto/opamp.proto
+++ b/internal/proto/opamp.proto
@@ -307,9 +307,7 @@ message TLSCertificate {
 
 message ConnectionSettingsOffers {
     // Hash of all settings, including settings that may be omitted from this message
-    // because they are unchanged. The Agent should remember the hash and include
-    // it in the subsequent ConnectionStatuses message, in the last_connection_settings_hash
-    // field.
+    // because they are unchanged.
     bytes hash = 1;
 
     // Settings to connect to the OpAMP Server.

--- a/protobufs/opamp.pb.go
+++ b/protobufs/opamp.pb.go
@@ -1334,9 +1334,7 @@ type ConnectionSettingsOffers struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Hash of all settings, including settings that may be omitted from this message
-	// because they are unchanged. The Agent should remember the hash and include
-	// it in the subsequent ConnectionStatuses message, in the last_connection_settings_hash
-	// field.
+	// because they are unchanged.
 	Hash []byte `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	// Settings to connect to the OpAMP Server.
 	// If this field is not set then the Agent should assume that the settings are


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opamp-go/issues/77

We previously delivered the data received in one ServerToAgent message using
multiple callbacks. This encouraged piecemeal processing and resulted in
multiple state changes when only one would be sufficient.

The new OnMessage callback delivers all data that can affect the state at once
which makes it possible process it in one pass. In the Supervisor this allows
to restart the Agent only once when applying changes that result in config
file change.