### PR TITLE
Convert NextMessage.nextMessage to a pointer

### DIFF
--- a/client/internal/sender.go
+++ b/client/internal/sender.go
@@ -35,7 +35,10 @@ type SenderCommon struct {
 }
 
 func NewSenderCommon() SenderCommon {
-	return SenderCommon{hasPendingMessage: make(chan struct{}, 1)}
+	return SenderCommon{
+		hasPendingMessage: make(chan struct{}, 1),
+		nextMessage:       NewNextMessage(),
+	}
 }
 
 // ScheduleSend signals to HTTPSender that the message in NextMessage struct


### PR DESCRIPTION
ProtoBuf messages are non-copy (see https://golang.org/issues/8005),
so instead of storing by value we store a pointer.

Resolves https://github.com/open-telemetry/opamp-go/issues/86