### PR TITLE
Remove pmm-sumo from approvers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Approvers ([@open-telemetry/opamp-go-approvers](https://github.com/orgs/open-tel
 - [Alex Boten](https://github.com/codeboten), Lightstep
 - [Andy Keller](https://github.com/andykellr), observIQ
 - [Anthony Mirabella](https://github.com/Aneurysm9), AWS
+
+Emeritus Approvers
+
 - [Przemek Maciolek](https://github.com/pmm-sumo), Sumo Logic
 
 Maintainers ([@open-telemetry/opamp-go-maintainers](https://github.com/orgs/open-telemetry/teams/opamp-go-maintainers)):


### PR DESCRIPTION
Dear community, due to a transition into another role at a different organisation I am no longer able to allocate time to be an approver of OpAMP

Thank you all, it was a great pleasure to work with you and also a great opportunity to learn