### PR TITLE
Correctly handle status compression on the server side

### DIFF
--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -206,12 +206,7 @@ func (c *ClientCommon) PrepareFirstMessage(ctx context.Context) error {
 			msg.EffectiveConfig = cfg
 			msg.RemoteConfigStatus = c.ClientSyncedState.RemoteConfigStatus()
 			msg.PackageStatuses = c.ClientSyncedState.PackageStatuses()
-
-			if c.PackagesStateProvider != nil {
-				// We have a state provider, so package related capabilities can work.
-				msg.Capabilities |= protobufs.AgentCapabilities_AcceptsPackages
-				msg.Capabilities |= protobufs.AgentCapabilities_ReportsPackageStatuses
-			}
+			msg.Capabilities = c.Capabilities
 		},
 	)
 	return nil


### PR DESCRIPTION
We check the omitted field and the corresponding capability bit to understand
if the compression was used.

Related to spec issue https://github.com/open-telemetry/opamp-spec/issues/109
The issue was discarded in favour of the implementation that does not
change the spec, but instead uses already existing information.