### PR TITLE
Don't call OnConnectFailed when failed to connect during shutdown

### DIFF
--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -121,7 +121,7 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (err error, retryAfter sh
 	var resp *http.Response
 	conn, resp, err := c.dialer.DialContext(ctx, c.url.String(), c.requestHeader)
 	if err != nil {
-		if c.common.Callbacks != nil {
+		if c.common.Callbacks != nil && !c.common.IsStopping() {
 			c.common.Callbacks.OnConnectFailed(err)
 		}
 		if resp != nil {


### PR DESCRIPTION
Fixes #111

Once `Stop()` is called on the websocket client we don't call `OnConnectFailed` handler if a dial fails.

Tested this fix on a system that was repeatedly showing the `OnConnectFailed` handler called during shutdown.