### PR TITLE
Require that instance_uid is ULID

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -117,6 +117,17 @@ func TestConnectNoServer(t *testing.T) {
 	})
 }
 
+func TestInvalidInstanceId(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		settings := createNoServerSettings()
+		prepareClient(t, &settings, client)
+		settings.InstanceUid = "invalidid"
+
+		err := client.Start(context.Background(), settings)
+		assert.Error(t, err)
+	})
+}
+
 func TestOnConnectFail(t *testing.T) {
 	testClients(t, func(t *testing.T, client OpAMPClient) {
 		var connectErr atomic.Value

--- a/client/internal/sender.go
+++ b/client/internal/sender.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"errors"
 
+	"github.com/oklog/ulid/v2"
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
@@ -67,6 +68,10 @@ func (h *SenderCommon) NextMessage() *NextMessage {
 func (h *SenderCommon) SetInstanceUid(instanceUid string) error {
 	if instanceUid == "" {
 		return errors.New("cannot set instance uid to empty value")
+	}
+
+	if _, err := ulid.ParseStrict(instanceUid); err != nil {
+		return err
 	}
 
 	h.nextMessage.Update(


### PR DESCRIPTION
Implements spec change https://github.com/open-telemetry/opamp-spec/pull/116