### PR TITLE
Make sure only one package syncing operation happens at a time

### DIFF
--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -104,5 +104,6 @@ func (c *httpClient) runUntilStopped(ctx context.Context) {
 		&c.common.ClientSyncedState,
 		c.common.PackagesStateProvider,
 		c.common.Capabilities,
+		&c.common.PackageSyncComplete,
 	)
 }

--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -54,6 +54,9 @@ type ClientCommon struct {
 
 	// Indicates that the Client is fully stopped.
 	stoppedSignal chan struct{}
+
+	// Mutex for Package Syncing
+	PackageSyncComplete sync.Mutex
 }
 
 // NewClientCommon creates a new ClientCommon.

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sync/atomic"
 	"time"
+	"sync"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/open-telemetry/opamp-go/internal"
@@ -68,10 +69,11 @@ func (h *HTTPSender) Run(
 	clientSyncedState *ClientSyncedState,
 	packagesStateProvider types.PackagesStateProvider,
 	capabilities protobufs.AgentCapabilities,
+	packageSyncComplete *sync.Mutex,
 ) {
 	h.url = url
 	h.callbacks = callbacks
-	h.receiveProcessor = newReceivedProcessor(h.logger, callbacks, h, clientSyncedState, packagesStateProvider, capabilities)
+	h.receiveProcessor = newReceivedProcessor(h.logger, callbacks, h, clientSyncedState, packagesStateProvider, capabilities, packageSyncComplete)
 
 	for {
 		pollingTimer := time.NewTimer(time.Millisecond * time.Duration(atomic.LoadInt64(&h.pollingIntervalMs)))

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -26,6 +27,9 @@ type receivedProcessor struct {
 
 	// Agent's capabilities defined at Start() time.
 	capabilities protobufs.AgentCapabilities
+
+	// Mutex for Package Syncing
+	packageSyncComplete *sync.Mutex
 }
 
 func newReceivedProcessor(
@@ -35,6 +39,7 @@ func newReceivedProcessor(
 	clientSyncedState *ClientSyncedState,
 	packagesStateProvider types.PackagesStateProvider,
 	capabilities protobufs.AgentCapabilities,
+	packageSyncComplete *sync.Mutex,
 ) receivedProcessor {
 	return receivedProcessor{
 		logger:                logger,
@@ -43,6 +48,7 @@ func newReceivedProcessor(
 		clientSyncedState:     clientSyncedState,
 		packagesStateProvider: packagesStateProvider,
 		capabilities:          capabilities,
+		packageSyncComplete:   packageSyncComplete,
 	}
 }
 
@@ -115,6 +121,7 @@ func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *pro
 					r.sender,
 					r.clientSyncedState,
 					r.packagesStateProvider,
+					r.packageSyncComplete,
 				)
 			} else {
 				r.logger.Debugf("Ignoring PackagesAvailable, agent does not have AcceptsPackages capability")

--- a/client/internal/wsreceiver.go
+++ b/client/internal/wsreceiver.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
@@ -30,13 +31,15 @@ func NewWSReceiver(
 	clientSyncedState *ClientSyncedState,
 	packagesStateProvider types.PackagesStateProvider,
 	capabilities protobufs.AgentCapabilities,
+	packageSyncComplete *sync.Mutex,
+
 ) *wsReceiver {
 	w := &wsReceiver{
 		conn:      conn,
 		logger:    logger,
 		sender:    sender,
 		callbacks: callbacks,
-		processor: newReceivedProcessor(logger, callbacks, sender, clientSyncedState, packagesStateProvider, capabilities),
+		processor: newReceivedProcessor(logger, callbacks, sender, clientSyncedState, packagesStateProvider, capabilities, packageSyncComplete),
 	}
 
 	return w

--- a/client/internal/wsreceiver_test.go
+++ b/client/internal/wsreceiver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"sync"
 
 	"github.com/stretchr/testify/assert"
 
@@ -74,7 +75,8 @@ func TestServerToAgentCommand(t *testing.T) {
 				remoteConfigStatus: &protobufs.RemoteConfigStatus{},
 			}
 			sender := WSSender{}
-			receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, &sender, &clientSyncedState, nil, 0)
+			var mx sync.Mutex
+			receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, &sender, &clientSyncedState, nil, 0, &mx)
 			receiver.processor.ProcessReceivedMessage(context.Background(), &protobufs.ServerToAgent{
 				Command: test.command,
 			})
@@ -97,7 +99,8 @@ func TestServerToAgentCommandExclusive(t *testing.T) {
 		},
 	}
 	clientSyncedState := ClientSyncedState{}
-	receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, nil, &clientSyncedState, nil, 0)
+	var mx sync.Mutex
+	receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, nil, &clientSyncedState, nil, 0, &mx)
 	receiver.processor.ProcessReceivedMessage(context.Background(), &protobufs.ServerToAgent{
 		Command: &protobufs.ServerToAgentCommand{
 			Type: protobufs.ServerToAgentCommand_Restart,

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -237,6 +237,7 @@ func (c *wsClient) runOneCycle(ctx context.Context) {
 		&c.common.ClientSyncedState,
 		c.common.PackagesStateProvider,
 		c.common.Capabilities,
+		&c.common.PackageSyncComplete,
 	)
 	r.ReceiverLoop(ctx)
 


### PR DESCRIPTION
This is the revised PR for issue https://github.com/open-telemetry/opamp-go/issues/84 . As proposed I am in the process to write a test case for testing the changes (It will take some time as I am new to the codebase).