### PR TITLE
Add Disconnect() method to client connections

### DIFF
--- a/server/httpconnection.go
+++ b/server/httpconnection.go
@@ -9,7 +9,7 @@ import (
 	"github.com/open-telemetry/opamp-go/server/types"
 )
 
-var errInvalidHTTPConnection = errors.New("cannot Send() over HTTP connection")
+var errInvalidHTTPConnection = errors.New("cannot operate over HTTP connection")
 
 // httpConnection represents an OpAMP connection over a plain HTTP connection.
 // Only one response is possible to send when using plain HTTP connection
@@ -31,6 +31,7 @@ func (c httpConnection) Send(_ context.Context, _ *protobufs.ServerToAgent) erro
 	return errInvalidHTTPConnection
 }
 
-func (c httpConnection) Close() error {
-	return c.conn.Close()
+func (c httpConnection) Disconnect() error {
+	// Disconnect() should not be called for plain HTTP connection.
+	return errInvalidHTTPConnection
 }

--- a/server/httpconnection.go
+++ b/server/httpconnection.go
@@ -9,7 +9,11 @@ import (
 	"github.com/open-telemetry/opamp-go/server/types"
 )
 
-var errInvalidHTTPConnection = errors.New("cannot operate over HTTP connection")
+// ErrInvalidHTTPConnection represents an event of misuse function for plain HTTP
+// connection, such as httpConnection.Send() or httpConnection.Disconnect().
+// Usage will not result with change but return this error to indicate current state
+// might not be as expected.
+var ErrInvalidHTTPConnection = errors.New("cannot operate over HTTP connection")
 
 // httpConnection represents an OpAMP connection over a plain HTTP connection.
 // Only one response is possible to send when using plain HTTP connection
@@ -28,10 +32,10 @@ var _ types.Connection = (*httpConnection)(nil)
 func (c httpConnection) Send(_ context.Context, _ *protobufs.ServerToAgent) error {
 	// Send() should not be called for plain HTTP connection. Instead, the response will
 	// be sent after the onMessage callback returns.
-	return errInvalidHTTPConnection
+	return ErrInvalidHTTPConnection
 }
 
 func (c httpConnection) Disconnect() error {
 	// Disconnect() should not be called for plain HTTP connection.
-	return errInvalidHTTPConnection
+	return ErrInvalidHTTPConnection
 }

--- a/server/httpconnection.go
+++ b/server/httpconnection.go
@@ -30,3 +30,7 @@ func (c httpConnection) Send(_ context.Context, _ *protobufs.ServerToAgent) erro
 	// be sent after the onMessage callback returns.
 	return errInvalidHTTPConnection
 }
+
+func (c httpConnection) Close() error {
+	return c.conn.Close()
+}

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -51,10 +51,6 @@ func TestServerStartStop(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestServerStartCloseConnection(t *testing.T) {
-
-}
-
 func TestServerStartRejectConnection(t *testing.T) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -126,7 +126,7 @@ func TestServerStartAcceptConnection(t *testing.T) {
 	eventually(t, func() bool { return atomic.LoadInt32(&connectionCloseCalled) == 1 })
 }
 
-func TestServerCloseConnection(t *testing.T) {
+func TestDisconnectWSConnection(t *testing.T) {
 	connectionCloseCalled := int32(0)
 	callback := CallbacksStruct{
 		OnConnectionCloseFunc: func(conn types.Connection) {
@@ -148,11 +148,15 @@ func TestServerCloseConnection(t *testing.T) {
 
 	// Close connection from server side
 	srvConn := wsConnection{wsConn: conn}
-	err = srvConn.Close()
-
+	err = srvConn.Disconnect()
 	assert.NoError(t, err)
 
-	// Verify that the Server receives the closing notification.
+	// Verify connection disconnected by re-close it
+	err = conn.Close()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "close tcp")
+
+	// Verify connection disconnected from server side
 	eventually(t, func() bool { return atomic.LoadInt32(&connectionCloseCalled) == 1 })
 }
 

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -130,7 +130,7 @@ func TestDisconnectHttpConnection(t *testing.T) {
 	// Verify Disconnect() results with Invalid HTTP Connection error
 	err := httpConnection{}.Disconnect()
 	assert.Error(t, err)
-	assert.Equal(t, errInvalidHTTPConnection, err)
+	assert.Equal(t, ErrInvalidHTTPConnection, err)
 }
 
 func TestDisconnectWSConnection(t *testing.T) {

--- a/server/types/connection.go
+++ b/server/types/connection.go
@@ -19,4 +19,8 @@ type Connection interface {
 	// Blocks until the message is sent.
 	// Should return as soon as possible if the ctx is cancelled.
 	Send(ctx context.Context, message *protobufs.ServerToAgent) error
+
+	// Close closes the network connection.
+	// Any blocked Read or Write operations will be unblocked and return errors.
+	Close() error
 }

--- a/server/types/connection.go
+++ b/server/types/connection.go
@@ -20,7 +20,7 @@ type Connection interface {
 	// Should return as soon as possible if the ctx is cancelled.
 	Send(ctx context.Context, message *protobufs.ServerToAgent) error
 
-	// Close closes the network connection.
+	// Disconnect closes the network connection.
 	// Any blocked Read or Write operations will be unblocked and return errors.
-	Close() error
+	Disconnect() error
 }

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -29,3 +29,7 @@ func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) 
 	}
 	return c.wsConn.WriteMessage(websocket.BinaryMessage, bytes)
 }
+
+func (c wsConnection) Close() error {
+	return c.wsConn.Close()
+}

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -30,6 +30,6 @@ func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) 
 	return c.wsConn.WriteMessage(websocket.BinaryMessage, bytes)
 }
 
-func (c wsConnection) Close() error {
+func (c wsConnection) Disconnect() error {
 	return c.wsConn.Close()
 }


### PR DESCRIPTION
Resolves #91 

This enables OpAMP to close the network connection to an agent from the server side