### PR TITLE
Add CustomMessage to AgentToServer and ServerToAgent

### DIFF
--- a/client/types/callbacks.go
+++ b/client/types/callbacks.go
@@ -114,6 +114,12 @@ type Callbacks interface {
 
 	// OnCommand is called when the Server requests that the connected Agent perform a command.
 	OnCommand(command *protobufs.ServerToAgentCommand) error
+
+	// OnCustomMessage is called when either a CustomMessageResponse is sent from the server or a new CustomMessage
+	// message is sent from the server, or both. Either the response or the message will be non-nil. A
+	// CustomMessageResponse will be returned to the server based on the return values. To ignore an unsupported message,
+	// return false, nil.
+	OnCustomMessage(ctx context.Context, lastResponse *protobufs.CustomMessageResponse, message *protobufs.CustomMessage) (ok bool, err error)
 }
 
 type CallbacksStruct struct {

--- a/internal/proto/opamp.proto
+++ b/internal/proto/opamp.proto
@@ -482,14 +482,17 @@ message ServerToAgentCommand {
 // the type is not recognized, the message MUST be ignored and a reply with CustomMessageResponse with Status IGNORED
 // MUST be sent.
 message CustomMessage {
+    // Hash of all fields of this message. Used to identify this message in the CustomMessageResponse.
+    bytes hash = 1;
+
     // The message type should a reverse FQDN that uniquely identifies the custom message type.
-    string type = 0;
+    string type = 2;
 
     // Optional string body of the message. The Agent and Server must agree on the format of the contents.
-    string body = 1;
+    string body = 3;
 
     // Optional string body of the message. The Agent and Server must agree on the format of the contents.
-    bytes data = 2;
+    bytes data = 4;
 }
 
 // CustomMessageResponse MUST be returned in response to a CustomMessage. It allows the sender of the CustomMessage to
@@ -515,7 +518,10 @@ message CustomMessageResponse {
     Status status = 1;
 
     // Error message in the string form, typically human readable.
-    string error_message = 1;
+    string error_message = 2;
+
+    // The hash of the CustomMessage that was last received in the CustomMessage.hash field.
+    bytes last_custom_message_hash = 3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/internal/proto/opamp.proto
+++ b/internal/proto/opamp.proto
@@ -83,6 +83,12 @@ message AgentToServer {
     }
     // Bit flags as defined by AgentToServerFlags bit masks.
     AgentToServerFlags flags = 10;
+
+    // CustomMessage allows the OpAMP connection to be used to send messages that are not defined by the OpAMP protocol.
+    CustomMessage custom_message = 11;
+
+    // CustomMessageResponse MUST be sent in response to a CustomMessage in a ServerToAgent message.
+    CustomMessageResponse custom_message_response = 12;
 }
 
 // AgentDisconnect is the last message sent from the Agent to the Server. The Server
@@ -150,6 +156,12 @@ message ServerToAgent {
     // with fields other than instance_uid and capabilities. If specified, other fields will be ignored and the command
     // will be performed.
     ServerToAgentCommand command = 9;
+
+    // CustomMessage allows the OpAMP connection to be used to send messages that are not defined by the OpAMP protocol.
+    CustomMessage custom_message = 10;
+
+    // CustomMessageResponse MUST be sent in response to a CustomMessage in a AgentToServer message.
+    CustomMessageResponse custom_message_response = 11;
 }
 
 enum ServerCapabilities {
@@ -463,6 +475,47 @@ message ServerToAgentCommand {
         Restart = 0;
     }
     CommandType type = 1;
+}
+
+// CustomMessage allows for custom messages to be sent between the Agent and Server. It is supported on ServerToAgent
+// and AgentToServer. It requires that the agent and server both agree on the contents and encoding of the message. If
+// the type is not recognized, the message MUST be ignored and a reply with CustomMessageResponse with Status IGNORED
+// MUST be sent.
+message CustomMessage {
+    // The message type should a reverse FQDN that uniquely identifies the custom message type.
+    string type = 0;
+
+    // Optional string body of the message. The Agent and Server must agree on the format of the contents.
+    string body = 1;
+
+    // Optional string body of the message. The Agent and Server must agree on the format of the contents.
+    bytes data = 2;
+}
+
+// CustomMessageResponse MUST be returned in response to a CustomMessage. It allows the sender of the CustomMessage to
+// determine if the message was successfully handled.
+//
+// Handling a CustomMessage may result in another CustomMessage in response, e.g. a Server could request information
+// from an Agent and expect the Agent to reply with that information in a separate CustomMessage. The
+// CustomMessageResponse allows the sender to know if it should expect a reply or if the message was ignored or was an
+// error.
+message CustomMessageResponse {
+    enum Status {
+        // The CustomMessage was ignored because the message type was not recognized or supported. The error_message may
+        // contain additional information.
+        IGNORED = 0;
+
+        // The CustomMessage was handled successfully.
+        OK = 1;
+
+        // The CustomMessage was unable to be handled successfully. The error_message should contain additional
+        // information.
+        ERROR = 2;
+    }
+    Status status = 1;
+
+    // Error message in the string form, typically human readable.
+    string error_message = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
See https://github.com/open-telemetry/opamp-spec/issues/49

It was easiest for me to start here. If we agree on the direction of this, I plan to do the following: 

* update the opamp-spec
* add OnCustomMessage method to the client Callbacks interfaces
* add SendCustomMessage to the OpAMPClient
* add implementation to the client and server
* add tests for that implementation