### PR TITLE
Add client-side support for datetime value of Retry-After header

### DIFF
--- a/internal/retryafter.go
+++ b/internal/retryafter.go
@@ -29,11 +29,11 @@ func ExtractRetryAfterHeader(resp *http.Response) OptionalDuration {
 				retryInterval := time.Duration(retryIntervalSec) * time.Second
 				return OptionalDuration{Defined: true, Duration: retryInterval}
 			}
-			// Try to parse retryAfterHTTPHeader as HTTP-date
+			// Try parse retryAfterHTTPHeader as HTTP-date
 			// See https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3
-			t, err := time.Parse(time.RFC1123, retryAfter)
+			t, err := http.ParseTime(retryAfter)
 			if err == nil {
-				retryInterval := time.Until(t) * time.Second
+				retryInterval := time.Until(t)
 				return OptionalDuration{Defined: true, Duration: retryInterval}
 			}
 		}

--- a/internal/retryafter_test.go
+++ b/internal/retryafter_test.go
@@ -1,0 +1,100 @@
+package internal
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func response503() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Header:     map[string][]string{},
+	}
+}
+
+func TestExtractRetryAfterHeaderDelaySeconds(t *testing.T) {
+	// Generate random n > 0 int
+	rand.Seed(time.Now().UnixNano())
+	retryIntervalSec := rand.Intn(9999)
+
+	// Generate a 503 status code response with Retry-After = n header
+	resp := response503()
+	resp.Header.Add(retryAfterHTTPHeader, strconv.Itoa(retryIntervalSec))
+
+	expectedDuration := OptionalDuration{
+		Defined:  true,
+		Duration: time.Second * time.Duration(retryIntervalSec),
+	}
+	assert.Equal(t, expectedDuration, ExtractRetryAfterHeader(resp))
+}
+
+func TestExtractRetryAfterHeader429StatusCode(t *testing.T) {
+	// Generate random n > 0 int
+	rand.Seed(time.Now().UnixNano())
+	retryIntervalSec := rand.Intn(9999)
+
+	// Generate a 429 status code response with Retry-After = n header
+	resp := response503()
+	resp.StatusCode = http.StatusTooManyRequests
+	resp.Header.Add(retryAfterHTTPHeader, strconv.Itoa(retryIntervalSec))
+
+	expectedDuration := OptionalDuration{
+		Defined:  true,
+		Duration: time.Second * time.Duration(retryIntervalSec),
+	}
+	assert.Equal(t, expectedDuration, ExtractRetryAfterHeader(resp))
+}
+
+func TestExtractRetryAfterHeaderInvalidFormat(t *testing.T) {
+	// Generate a random n > 0 int
+	now := time.Now()
+	//rand.Seed(now.UnixNano())
+	retryIntervalSec := rand.Intn(9999)
+
+	// Set a response with Retry-After header = random n > 0 int
+	resp := response503()
+	ra := now.Add(time.Second * time.Duration(retryIntervalSec)).UTC()
+
+	// Verify non HTTP-date RFC1123 format isn't being parsed
+	resp.Header.Set(retryAfterHTTPHeader, ra.Format(time.RFC1123))
+	d := ExtractRetryAfterHeader(resp)
+	assert.NotNil(t, d)
+	assert.Equal(t, false, d.Defined)
+	assert.Equal(t, time.Duration(0), d.Duration)
+}
+
+func TestExtractRetryAfterHeaderHttpDate(t *testing.T) {
+	// Generate a random n > 0 int
+	now := time.Now()
+	//rand.Seed(now.UnixNano())
+	retryIntervalSec := rand.Intn(9999)
+
+	// Set a response with Retry-After header = random n > 0 int
+	resp := response503()
+	ra := now.Add(time.Second * time.Duration(retryIntervalSec)).UTC()
+
+	// Verify HTTP-date TimeFormat format is being parsed correctly
+	resp.Header.Set(retryAfterHTTPHeader, ra.Format(http.TimeFormat))
+	d := ExtractRetryAfterHeader(resp)
+	assert.NotNil(t, d)
+	assert.Equal(t, true, d.Defined)
+	assert.Less(t, d.Duration, time.Second*time.Duration(retryIntervalSec))
+
+	// Verify ANSI time format
+	resp.Header.Set(retryAfterHTTPHeader, ra.Format(time.ANSIC))
+	d = ExtractRetryAfterHeader(resp)
+	assert.NotNil(t, d)
+	assert.Equal(t, true, d.Defined)
+	assert.Less(t, d.Duration, time.Second*time.Duration(retryIntervalSec))
+
+	// Verify RFC850 time format
+	resp.Header.Set(retryAfterHTTPHeader, ra.Format(time.RFC850))
+	d = ExtractRetryAfterHeader(resp)
+	assert.NotNil(t, d)
+	assert.Equal(t, true, d.Defined)
+	assert.Less(t, d.Duration, time.Second*time.Duration(retryIntervalSec))
+}

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -78,34 +78,6 @@ func TestServerStartRejectConnection(t *testing.T) {
 	assert.EqualValues(t, "30", resp.Header.Get("Retry-After"))
 }
 
-func TestServerRejectConnectionTooManyRequests(t *testing.T) {
-	r := time.Now().Add(time.Second * 30).Format(time.RFC1123)
-	callbacks := CallbacksStruct{
-		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
-			// Reject the incoming HTTP connection.
-			return types.ConnectionResponse{
-				Accept:             false,
-				HTTPStatusCode:     429,
-				HTTPResponseHeader: map[string]string{"Retry-After": r},
-			}
-		},
-	}
-
-	// Start a Server.
-	settings := &StartSettings{Settings: Settings{Callbacks: callbacks}}
-	srv := startServer(t, settings)
-	defer srv.Stop(context.Background())
-
-	// Try to connect to the Server.
-	conn, resp, err := dialClient(settings)
-
-	// Verify that the connection is rejected and rejection data is available to the client.
-	assert.Nil(t, conn)
-	assert.Error(t, err)
-	assert.EqualValues(t, 429, resp.StatusCode)
-	assert.EqualValues(t, r, resp.Header.Get("Retry-After"))
-}
-
 func eventually(t *testing.T, f func() bool) {
 	assert.Eventually(t, f, 5*time.Second, 10*time.Millisecond)
 }


### PR DESCRIPTION
According to specifications, Retry-After header should be either seconds-delay or HTTP-date
https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3

Resolves #119 