### PR TITLE
Implement health checks in Supervisor

### DIFF
--- a/internal/examples/supervisor/supervisor/commander/commander.go
+++ b/internal/examples/supervisor/supervisor/commander/commander.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -16,12 +17,13 @@ import (
 // Commander can start/stop/restat the Agent executable and also watch for a signal
 // for the Agent process to finish.
 type Commander struct {
-	logger types.Logger
-	cfg    *config.Agent
-	args   []string
-	cmd    *exec.Cmd
-	doneCh chan struct{}
-	waitCh chan struct{}
+	logger  types.Logger
+	cfg     *config.Agent
+	args    []string
+	cmd     *exec.Cmd
+	doneCh  chan struct{}
+	waitCh  chan struct{}
+	running int64
 }
 
 func NewCommander(logger types.Logger, cfg *config.Agent, args ...string) (*Commander, error) {
@@ -61,6 +63,7 @@ func (c *Commander) Start(ctx context.Context) error {
 	}
 
 	c.logger.Debugf("Agent process started, PID=%d", c.cmd.Process.Pid)
+	atomic.StoreInt64(&c.running, 1)
 
 	go c.watch()
 
@@ -80,6 +83,7 @@ func (c *Commander) Restart(ctx context.Context) error {
 func (c *Commander) watch() {
 	c.cmd.Wait()
 	c.doneCh <- struct{}{}
+	atomic.StoreInt64(&c.running, 0)
 	close(c.waitCh)
 }
 
@@ -102,6 +106,10 @@ func (c *Commander) ExitCode() int {
 		return 0
 	}
 	return c.cmd.ProcessState.ExitCode()
+}
+
+func (c *Commander) IsRunning() bool {
+	return atomic.LoadInt64(&c.running) != 0
 }
 
 // Stop the Agent process. Sends SIGTERM to the process and wait for up 10 seconds
@@ -150,6 +158,8 @@ func (c *Commander) Stop(ctx context.Context) error {
 
 	// Wait for process to terminate
 	<-c.waitCh
+
+	atomic.StoreInt64(&c.running, 0)
 
 	// Let goroutine know process is finished.
 	close(finished)

--- a/internal/examples/supervisor/supervisor/healthchecker/healthchecker.go
+++ b/internal/examples/supervisor/supervisor/healthchecker/healthchecker.go
@@ -1,0 +1,41 @@
+package healthchecker
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type HttpHealthChecker struct {
+	endpoint string
+}
+
+func NewHttpHealthChecker(endpoint string) *HttpHealthChecker {
+	return &HttpHealthChecker{
+		endpoint: endpoint,
+	}
+}
+
+func (h *HttpHealthChecker) Check(ctx context.Context) error {
+
+	req, err := http.NewRequestWithContext(ctx, "GET", h.endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	client := http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health check on %s returned %d", h.endpoint, resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/examples/supervisor/supervisor/supervisor.go
+++ b/internal/examples/supervisor/supervisor/supervisor.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
@@ -19,6 +21,7 @@ import (
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/internal/examples/supervisor/supervisor/commander"
 	"github.com/open-telemetry/opamp-go/internal/examples/supervisor/supervisor/config"
+	"github.com/open-telemetry/opamp-go/internal/examples/supervisor/supervisor/healthchecker"
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
@@ -37,6 +40,10 @@ type Supervisor struct {
 	commander *commander.Commander
 
 	startedAt time.Time
+
+	healthCheckTicker  *backoff.Ticker
+	healthChecker      *healthchecker.HttpHealthChecker
+	lastHealthCheckErr error
 
 	// Supervisor's own config.
 	config config.Supervisor
@@ -217,6 +224,13 @@ service:
       service.name: %s
       service.version: %s
       service.instance.id: %s
+
+  # Enable extension to allow the Supervisor to check health.
+  extensions: [health_check]
+
+extensions:
+  health_check:
+    # TODO: choose the endpoint dynamically.
 `,
 		agentType,
 		s.agentVersion,
@@ -398,12 +412,59 @@ func (s *Supervisor) startAgent() {
 		return
 	}
 	s.startedAt = time.Now()
-	s.opampClient.SetHealth(
-		&protobufs.AgentHealth{
-			Up:                true,
-			StartTimeUnixNano: uint64(s.startedAt.UnixNano()),
-		},
-	)
+
+	// Prepare health checker
+	healthCheckBackoff := backoff.NewExponentialBackOff()
+	healthCheckBackoff.MaxInterval = 60 * time.Second
+	healthCheckBackoff.MaxElapsedTime = 0 // Never stop
+	if s.healthCheckTicker != nil {
+		s.healthCheckTicker.Stop()
+	}
+	s.healthCheckTicker = backoff.NewTicker(healthCheckBackoff)
+
+	// TODO: choose the port dynamically.
+	healthEndpoint := "http://localhost:13133"
+	s.healthChecker = healthchecker.NewHttpHealthChecker(healthEndpoint)
+}
+
+func (s *Supervisor) healthCheck() {
+	if !s.commander.IsRunning() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+
+	err := s.healthChecker.Check(ctx)
+	cancel()
+
+	if errors.Is(err, s.lastHealthCheckErr) {
+		// No difference from last check. Nothing new to report.
+		return
+	}
+
+	// Prepare OpAMP health report.
+	health := &protobufs.AgentHealth{
+		StartTimeUnixNano: uint64(s.startedAt.UnixNano()),
+	}
+
+	if err != nil {
+		// TODO: the Up field's usage may need to change once this issue is clarfied:
+		// https://github.com/open-telemetry/opamp-spec/issues/136
+		health.Up = false
+		health.LastError = err.Error()
+		s.logger.Errorf("Agent is not healthy: %s", health.LastError)
+	} else {
+		health.Up = true
+		s.logger.Debugf("Agent is healthy.")
+	}
+
+	// Report via OpAMP.
+	if err2 := s.opampClient.SetHealth(health); err2 != nil {
+		s.logger.Errorf("Could not report health. SetHealth returned: %v", err2)
+		return
+	}
+
+	s.lastHealthCheckErr = err
 }
 
 func (s *Supervisor) runAgentProcess() {
@@ -419,7 +480,8 @@ func (s *Supervisor) runAgentProcess() {
 		select {
 		case <-s.hasNewConfig:
 			restartTimer.Stop()
-			s.applyConfigWithAgentRestart()
+			s.stopAgentApplyConfig()
+			s.startAgent()
 
 		case <-s.commander.Done():
 			errMsg := fmt.Sprintf(
@@ -437,16 +499,18 @@ func (s *Supervisor) runAgentProcess() {
 
 		case <-restartTimer.C:
 			s.startAgent()
+
+		case <-s.healthCheckTicker.C:
+			s.healthCheck()
 		}
 	}
 }
 
-func (s *Supervisor) applyConfigWithAgentRestart() {
-	s.logger.Debugf("Restarting the agent with the new config.")
+func (s *Supervisor) stopAgentApplyConfig() {
+	s.logger.Debugf("Stopping the agent to apply new config.")
 	cfg := s.effectiveConfig.Load().(string)
 	s.commander.Stop(context.Background())
 	s.writeEffectiveConfigToFile(cfg, s.effectiveConfigFilePath)
-	s.startAgent()
 }
 
 func (s *Supervisor) writeEffectiveConfigToFile(cfg string, filePath string) {


### PR DESCRIPTION
The Supervisor now periodically polls Collector's
health check endpoint and reports the health status to the OpAMP Server.