### PR TITLE
Add State interface{} to types.Connection to share state between callbacks

### DIFF
--- a/server/httpconnection.go
+++ b/server/httpconnection.go
@@ -20,7 +20,8 @@ var ErrInvalidHTTPConnection = errors.New("cannot operate over HTTP connection")
 // and that response will be sent by OpAMP Server's HTTP request handler after the
 // onMessage callback returns.
 type httpConnection struct {
-	conn net.Conn
+	conn  net.Conn
+	state interface{}
 }
 
 func (c httpConnection) RemoteAddr() net.Addr {
@@ -38,4 +39,8 @@ func (c httpConnection) Send(_ context.Context, _ *protobufs.ServerToAgent) erro
 func (c httpConnection) Disconnect() error {
 	// Disconnect() should not be called for plain HTTP connection.
 	return ErrInvalidHTTPConnection
+}
+
+func (c httpConnection) State() interface{} {
+	return c.state
 }

--- a/server/types/callbacks.go
+++ b/server/types/callbacks.go
@@ -11,6 +11,7 @@ type ConnectionResponse struct {
 	Accept             bool
 	HTTPStatusCode     int
 	HTTPResponseHeader map[string]string
+	State              interface{}
 }
 
 type Callbacks interface {

--- a/server/types/connection.go
+++ b/server/types/connection.go
@@ -23,4 +23,7 @@ type Connection interface {
 	// Disconnect closes the network connection.
 	// Any blocked Read or Write operations will be unblocked and return errors.
 	Disconnect() error
+
+	// State will return the state provided in the ConnectResponse.
+	State() interface{}
 }

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -14,6 +14,7 @@ import (
 // wsConnection represents a persistent OpAMP connection over a WebSocket.
 type wsConnection struct {
 	wsConn *websocket.Conn
+	state  interface{}
 }
 
 var _ types.Connection = (*wsConnection)(nil)
@@ -32,4 +33,8 @@ func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) 
 
 func (c wsConnection) Disconnect() error {
 	return c.wsConn.Close()
+}
+
+func (c wsConnection) State() interface{} {
+	return c.state
 }


### PR DESCRIPTION
It can be useful to share state between opamp server callbacks. This PR adds `State interface{}` to types.ConnectionResponse and makes it available on the `type.Connection` via `State()`.

A specific use-case of this is to share information from the http.Request in OnConnecting with the OnMessage callback.

It could also be used to share connection state such as:
* client certificate
* duration
* message count

It may be possible to store some of this state in a map managed by the implementer of the server, but the existing serverimpl makes it trivial to share state between callbacks. Also, there is currently no overlapping fields between the OnConnecting method and the other callbacks making it impossible to share information from the request.

I also considered separating the callbacks into two groups and having OnConnecting return an implementation of the other 3 callbacks. This would allow any struct with any state to be returned by OnConnecting and the implementation of the other 3 callbacks could access that state as needed. This would require a bit more refactoring to implement.

We also discussed having the server generate a connection ID and passing it to all of the callbacks, but I prefer this approach.