### PR TITLE
Add TLSConfig into httpClient

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -83,9 +85,17 @@ func prepareSettings(t *testing.T, settings *types.StartSettings, c OpAMPClient)
 	require.NoError(t, err)
 	switch c.(type) {
 	case *httpClient:
-		u.Scheme = "http"
+		if settings.TLSConfig != nil {
+			u.Scheme = "https"
+		} else {
+			u.Scheme = "http"
+		}
 	case *wsClient:
-		u.Scheme = "ws"
+		if settings.TLSConfig != nil {
+			u.Scheme = "wss"
+		} else {
+			u.Scheme = "ws"
+		}
 	}
 	settings.OpAMPServerURL = u.String()
 }
@@ -303,6 +313,50 @@ func TestConnectWithHeader(t *testing.T) {
 		srv.Close()
 		_ = client.Stop(context.Background())
 	})
+}
+
+func TestConnectWithTLS(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		// Start a server.
+		srv := internal.StartTLSMockServer(t)
+		var conn atomic.Value
+		srv.OnConnect = func(r *http.Request) {
+			conn.Store(true)
+		}
+
+		certs := rootCAs(t, srv.GetHTTPTestServer())
+
+		// Start a client.
+		settings := types.StartSettings{
+			OpAMPServerURL: "wss://" + srv.Endpoint,
+			TLSConfig: &tls.Config{
+				RootCAs: certs,
+			},
+		}
+
+		startClient(t, settings, client)
+
+		// Wait for connection to be established.
+		eventually(t, func() bool { return conn.Load() != nil })
+
+		// Shutdown the Server and the client.
+		srv.Close()
+		_ = client.Stop(context.Background())
+	})
+}
+
+func rootCAs(t *testing.T, s *httptest.Server) *x509.CertPool {
+	certs := x509.NewCertPool()
+	for _, c := range s.TLS.Certificates {
+		roots, err := x509.ParseCertificates(c.Certificate[len(c.Certificate)-1])
+		if err != nil {
+			t.Fatalf("error parsing server's root cert: %v", err)
+		}
+		for _, root := range roots {
+			certs.AddCert(root)
+		}
+	}
+	return certs
 }
 
 func createRemoteConfig() *protobufs.AgentRemoteConfig {

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -45,6 +45,9 @@ func (c *httpClient) Start(ctx context.Context, settings types.StartSettings) er
 	// Prepare Server connection settings.
 	c.sender.SetRequestHeader(settings.Header)
 
+	// Add TLS configuration into httpClient
+	c.sender.AddTLSConfig(settings.TLSConfig)
+
 	if settings.EnableCompression {
 		c.sender.EnableCompression()
 	}

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -262,4 +263,12 @@ func (h *HTTPSender) SetPollingInterval(duration time.Duration) {
 func (h *HTTPSender) EnableCompression() {
 	h.compressionEnabled = true
 	h.requestHeader.Set(headerContentEncoding, encodingTypeGZip)
+}
+
+func (h *HTTPSender) AddTLSConfig(config *tls.Config) {
+	if config != nil {
+		h.client.Transport = &http.Transport{
+			TLSClientConfig: config,
+		}
+	}
 }

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -54,4 +55,46 @@ func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
 	assert.True(t, time.Since(start) > time.Second)
 	cancel()
 	srv.Close()
+}
+
+func TestAddTLSConfig(t *testing.T) {
+	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+
+	certificate, err := GenerateCertificate()
+	assert.NoError(t, err)
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+	}
+
+	sender.AddTLSConfig(tlsConfig)
+	assert.Equal(t, sender.client.Transport, &http.Transport{TLSClientConfig: tlsConfig})
+}
+
+func GenerateCertificate() (tls.Certificate, error) {
+
+	certPem := []byte(`-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----`)
+
+	keyPem := []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+-----END EC PRIVATE KEY-----`)
+
+	cert, err := tls.X509KeyPair(certPem, keyPem)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	return cert, nil
 }

--- a/client/internal/mockserver.go
+++ b/client/internal/mockserver.go
@@ -37,7 +37,7 @@ type MockServer struct {
 const headerContentType = "Content-Type"
 const contentTypeProtobuf = "application/x-protobuf"
 
-func StartMockServer(t *testing.T) *MockServer {
+func newMockServer(t *testing.T) (*MockServer, *http.ServeMux) {
 	srv := &MockServer{
 		t:                t,
 		expectedHandlers: make(chan receivedMessageHandler, 0),
@@ -65,6 +65,12 @@ func StartMockServer(t *testing.T) *MockServer {
 		},
 	)
 
+	return srv, m
+}
+
+func StartMockServer(t *testing.T) *MockServer {
+	srv, m := newMockServer(t)
+
 	srv.srv = httptest.NewServer(m)
 
 	u, err := url.Parse(srv.srv.URL)
@@ -76,6 +82,26 @@ func StartMockServer(t *testing.T) *MockServer {
 	testhelpers.WaitForEndpoint(srv.Endpoint)
 
 	return srv
+}
+
+func StartTLSMockServer(t *testing.T) *MockServer {
+	srv, m := newMockServer(t)
+
+	srv.srv = httptest.NewTLSServer(m)
+
+	u, err := url.Parse(srv.srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.Endpoint = u.Host
+
+	testhelpers.WaitForEndpoint(srv.Endpoint)
+
+	return srv
+}
+
+func (m *MockServer) GetHTTPTestServer() *httptest.Server {
+	return m.srv
 }
 
 // EnableExpectMode enables the expect mode that allows using Expect() method


### PR DESCRIPTION
In order to support HTTPs connections with certificate between Agents and Server, TLSConfig shall be passed to http.Client on HTTPSender structure.

A new function AddTLSConfig was created on httpsender.go to handle that, which is called during Start process of OPAMP httpClient.
