### PR TITLE
Use upload token with codecov to avoid failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.out
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
Presumably this should help avoid failures, see https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954