### PR TITLE
Explain in CONTRIBUTING.md that opamp-spec submodule is needed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,18 @@
 
 ## Generate Protobuf Go Files
 
-Make sure you have Docker installed.
+1. Make sure `opamp-go/internal/opamp-spec` submodule files exist. You can do this
+either by cloning the `opamp-go` repo with submodules the first time, e.g. 
+`git clone --recurse-submodules git@github.com:open-telemetry/opamp-go.git`.
+Alternatively, if you already cloned `opamp-go` without the submodule then
+execute `git submodule update --init` to fetch all files for `opamp-spec` submodule.
+Note that `opamp-spec` submodule requires ssh git cloning access to github and won't
+work if you only have https access.
 
-Run `make gen-proto`. This should compile `internal/proto/*.proto` files to 
+2. Make sure you have Docker installed and running.
+
+3. Run `make gen-proto`. This should compile `internal/proto/*.proto` files to 
 `internal/protobufs/*.pb.go` files.
+
+Note that this is tested on linux/amd64 and darwin/amd64 and is known to not work
+on darwin/arm64 (M1/M2 Macs). Fixes are welcome.

--- a/makefile
+++ b/makefile
@@ -48,6 +48,13 @@ OTEL_DOCKER_PROTOBUF ?= otel/build-protobuf:0.14.0
 .PHONY: gen-proto
 gen-proto:
 	mkdir -p ${PWD}/internal/proto/
+
+	@if [ ! -d "${PWD}/internal/opamp-spec/proto" ]; then \
+		echo "${PWD}/internal/opamp-spec/proto does not exist."; \
+		echo "Run \`git submodule update --init\` to fetch the submodule"; \
+		exit 1; \
+	fi
+
 	$(foreach file,$(BASELINE_PROTO_FILES),$(call exec-command,docker run --rm -v${PWD}:${PWD} \
         -w${PWD} $(OTEL_DOCKER_PROTOBUF) --proto_path=${PWD}/internal/opamp-spec/proto/ \
         --go_out=${PWD}/internal/proto/ -I${PWD}/internal/proto/ ${PWD}/$(file)))


### PR DESCRIPTION
The submodule is necessary for `make gen-proto` target.

Also added a check in makefile to verify that the submodule is cloned.