### PR TITLE
Adding Case Server not found and printing connection error logs

### DIFF
--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -117,6 +117,7 @@ func (h *HTTPSender) SetRequestHeader(header http.Header) {
 func (h *HTTPSender) makeOneRequestRoundtrip(ctx context.Context) {
 	resp, err := h.sendRequestWithRetries(ctx)
 	if err != nil {
+		h.logger.Errorf("%v", err)
 		return
 	}
 	if resp == nil {
@@ -166,6 +167,9 @@ func (h *HTTPSender) sendRequestWithRetries(ctx context.Context) (*http.Response
 					case http.StatusTooManyRequests, http.StatusServiceUnavailable:
 						interval = recalculateInterval(interval, resp)
 						err = fmt.Errorf("server response code=%d", resp.StatusCode)
+
+					case http.StatusNotFound:
+						return nil, fmt.Errorf("failed to connect to the server, server not found: %d", resp.StatusCode)
 
 					default:
 						return nil, fmt.Errorf("invalid response from server: %d", resp.StatusCode)


### PR DESCRIPTION
1. Client emits logs when received any status error while trying to perform http connection to the server
2. Adding ServerNotFound case, while performing http connection and returning back the error to the sender with the message, which can be used by calling request for performing log operations