### PR TITLE
Adding missing error log statement when HTTP sending fails

### DIFF
--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -168,9 +168,6 @@ func (h *HTTPSender) sendRequestWithRetries(ctx context.Context) (*http.Response
 						interval = recalculateInterval(interval, resp)
 						err = fmt.Errorf("server response code=%d", resp.StatusCode)
 
-					case http.StatusNotFound:
-						return nil, fmt.Errorf("failed to connect to the server, server not found: %d", resp.StatusCode)
-
 					default:
 						return nil, fmt.Errorf("invalid response from server: %d", resp.StatusCode)
 					}

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -117,6 +117,7 @@ func (h *HTTPSender) SetRequestHeader(header http.Header) {
 func (h *HTTPSender) makeOneRequestRoundtrip(ctx context.Context) {
 	resp, err := h.sendRequestWithRetries(ctx)
 	if err != nil {
+		h.logger.Errorf("%v", err)
 		return
 	}
 	if resp == nil {
@@ -166,6 +167,9 @@ func (h *HTTPSender) sendRequestWithRetries(ctx context.Context) (*http.Response
 					case http.StatusTooManyRequests, http.StatusServiceUnavailable:
 						interval = recalculateInterval(interval, resp)
 						err = fmt.Errorf("server response code=%d", resp.StatusCode)
+
+					case http.StatusNotFound:
+						return nil, fmt.Errorf("failed to connect to the server, server not found: %d", resp.StatusCode)
 
 					default:
 						return nil, fmt.Errorf("invalid response from server: %d", resp.StatusCode)

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -14,36 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHTTPSender_makeOneRequestRoundtrip(t *testing.T) {
-	srv := StartMockServer(t)
-	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	url := "http://" + srv.Endpoint
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
-	sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
-		msg.AgentDescription = &protobufs.AgentDescription{
-			IdentifyingAttributes: []*protobufs.KeyValue{{
-				Key: "service.name",
-				Value: &protobufs.AnyValue{
-					Value: &protobufs.AnyValue_StringValue{StringValue: "test-service"},
-				},
-			}},
-		}
-	})
-	sender.callbacks = types.CallbacksStruct{
-		OnConnectFunc: func() {
-		},
-		OnConnectFailedFunc: func(_ error) {
-		},
-	}
-	sender.url = url
-	sender.makeOneRequestRoundtrip(ctx)
-	cancel()
-	srv.Close()
-}
-
 func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
 
 	var connectionAttempts int64
@@ -83,33 +53,6 @@ func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, time.Since(start) > time.Second)
-	cancel()
-	srv.Close()
-}
-
-func TestHTTPSenderRetryForStatusNotFound(t *testing.T) {
-
-	srv := StartMockServer(t)
-	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	url := "http://" + srv.Endpoint
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
-	sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
-		msg.AgentDescription = &protobufs.AgentDescription{
-			IdentifyingAttributes: []*protobufs.KeyValue{{
-				Key: "service.name",
-				Value: &protobufs.AnyValue{
-					Value: &protobufs.AnyValue_StringValue{StringValue: "test-service"},
-				},
-			}},
-		}
-	})
-	sender.url = url
-	resp, err := sender.sendRequestWithRetries(ctx)
-	assert.Error(t, err)
-	assert.Nil(t, resp)
 	cancel()
 	srv.Close()
 }


### PR DESCRIPTION
1. Client emits logs when receiving any error while trying to perform an HTTP connection to the server