### PR TITLE
Use os.type instead of os.family

### DIFF
--- a/internal/examples/agent/agent/agent.go
+++ b/internal/examples/agent/agent/agent.go
@@ -150,7 +150,7 @@ func (agent *Agent) createAgentIdentity() {
 		},
 		NonIdentifyingAttributes: []*protobufs.KeyValue{
 			{
-				Key: "os.family",
+				Key: "os.type",
 				Value: &protobufs.AnyValue{
 					Value: &protobufs.AnyValue_StringValue{
 						StringValue: runtime.GOOS,

--- a/internal/examples/supervisor/supervisor/supervisor.go
+++ b/internal/examples/supervisor/supervisor/supervisor.go
@@ -204,7 +204,7 @@ func (s *Supervisor) createAgentDescription() *protobufs.AgentDescription {
 			keyVal("service.version", s.agentVersion),
 		},
 		NonIdentifyingAttributes: []*protobufs.KeyValue{
-			keyVal("os.family", runtime.GOOS),
+			keyVal("os.type", runtime.GOOS),
 			keyVal("host.name", hostname),
 		},
 	}


### PR DESCRIPTION
The semantic conventions define `os.type`, but the examples use `os.family`. Let's follow the convention!