### PR TITLE
Fix deadlock from Stop() called from callbacks

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -37,9 +37,11 @@ type OpAMPClient interface {
 	// May be called only once.
 	// After this call returns successfully it is guaranteed that no
 	// callbacks will be called. Stop() will cancel context of any in-fly
-	// callbacks, but will wait until such in-fly callbacks are returned before
-	// Stop returns, so make sure the callbacks don't block infinitely and react
-	// promptly to context cancellations.
+	// callbacks.
+	//
+	// If a callback is in progress (e.g. OnMessage is called but not finished)
+	// Stop() initiates stopping and returns without waiting for stopping to finish.
+	//
 	// Once stopped OpAMPClient cannot be started again.
 	Stop(ctx context.Context) error
 

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -13,8 +13,9 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/open-telemetry/opamp-go/internal"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/open-telemetry/opamp-go/internal"
 
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -36,7 +37,7 @@ type HTTPSender struct {
 	url                string
 	logger             types.Logger
 	client             *http.Client
-	callbacks          types.Callbacks
+	callbacks          *CallbacksWrapper
 	pollingIntervalMs  int64
 	compressionEnabled bool
 
@@ -70,7 +71,7 @@ func NewHTTPSender(logger types.Logger) *HTTPSender {
 func (h *HTTPSender) Run(
 	ctx context.Context,
 	url string,
-	callbacks types.Callbacks,
+	callbacks *CallbacksWrapper,
 	clientSyncedState *ClientSyncedState,
 	packagesStateProvider types.PackagesStateProvider,
 	capabilities protobufs.AgentCapabilities,

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/open-telemetry/opamp-go/client/types"
 	sharedinternal "github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/protobufs"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
@@ -41,12 +42,12 @@ func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
 			}},
 		}
 	})
-	sender.callbacks = types.CallbacksStruct{
+	sender.callbacks = NewCallbacksWrapper(types.CallbacksStruct{
 		OnConnectFunc: func() {
 		},
 		OnConnectFailedFunc: func(_ error) {
 		},
-	}
+	})
 	sender.url = url
 	start := time.Now()
 	resp, err := sender.sendRequestWithRetries(ctx)

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -13,7 +13,7 @@ type receivedProcessor struct {
 	logger types.Logger
 
 	// Callbacks to call for corresponding messages.
-	callbacks types.Callbacks
+	callbacks *CallbacksWrapper
 
 	// A sender to cooperate with when the received message has an impact on
 	// what will be sent later.
@@ -30,7 +30,7 @@ type receivedProcessor struct {
 
 func newReceivedProcessor(
 	logger types.Logger,
-	callbacks types.Callbacks,
+	callbacks *CallbacksWrapper,
 	sender Sender,
 	clientSyncedState *ClientSyncedState,
 	packagesStateProvider types.PackagesStateProvider,

--- a/client/internal/wsreceiver.go
+++ b/client/internal/wsreceiver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gorilla/websocket"
+
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -15,7 +16,7 @@ type wsReceiver struct {
 	conn      *websocket.Conn
 	logger    types.Logger
 	sender    *WSSender
-	callbacks types.Callbacks
+	callbacks *CallbacksWrapper
 	processor receivedProcessor
 }
 
@@ -23,7 +24,7 @@ type wsReceiver struct {
 // messages from the server.
 func NewWSReceiver(
 	logger types.Logger,
-	callbacks types.Callbacks,
+	callbacks *CallbacksWrapper,
 	conn *websocket.Conn,
 	sender *WSSender,
 	clientSyncedState *ClientSyncedState,

--- a/client/internal/wsreceiver_test.go
+++ b/client/internal/wsreceiver_test.go
@@ -77,7 +77,7 @@ func TestServerToAgentCommand(t *testing.T) {
 				remoteConfigStatus: &protobufs.RemoteConfigStatus{},
 			}
 			sender := WSSender{}
-			receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, &sender, &clientSyncedState, nil, 0)
+			receiver := NewWSReceiver(TestLogger{t}, NewCallbacksWrapper(callbacks), nil, &sender, &clientSyncedState, nil, 0)
 			receiver.processor.ProcessReceivedMessage(context.Background(), &protobufs.ServerToAgent{
 				Command: test.command,
 			})
@@ -100,7 +100,7 @@ func TestServerToAgentCommandExclusive(t *testing.T) {
 		},
 	}
 	clientSyncedState := ClientSyncedState{}
-	receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, nil, &clientSyncedState, nil, 0)
+	receiver := NewWSReceiver(TestLogger{t}, NewCallbacksWrapper(callbacks), nil, nil, &clientSyncedState, nil, 0)
 	receiver.processor.ProcessReceivedMessage(context.Background(), &protobufs.ServerToAgent{
 		Command: &protobufs.ServerToAgentCommand{
 			Type: protobufs.CommandType_CommandType_Restart,


### PR DESCRIPTION
Calling Stop() from callbacks may result in a deadlock if the callback is called because a message is received. Stop() will wait for receiver to stop, but receiver can't stop until the callback is returned.

This change allow Stop() to initiate stopping and return without waiting for Stop() to finish.

This ability is important for implementing use cases where connection settings offer is received and the callback needs to Stop() the current OpAMP client and reconnect again using the new settings.