### PR TITLE
Replace Connection.RemoteAddr() by Connection()

### DIFF
--- a/server/httpconnection.go
+++ b/server/httpconnection.go
@@ -23,8 +23,8 @@ type httpConnection struct {
 	conn net.Conn
 }
 
-func (c httpConnection) RemoteAddr() net.Addr {
-	return c.conn.RemoteAddr()
+func (c httpConnection) Connection() net.Conn {
+	return c.conn
 }
 
 var _ types.Connection = (*httpConnection)(nil)

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -123,7 +123,7 @@ func TestServerStartAcceptConnection(t *testing.T) {
 	assert.True(t, atomic.LoadInt32(&connectionCloseCalled) == 0)
 
 	// Verify that the RemoteAddr is correct.
-	require.Equal(t, conn.LocalAddr().String(), srvConn.RemoteAddr().String())
+	require.Equal(t, conn.LocalAddr().String(), srvConn.Connection().RemoteAddr().String())
 
 	// Close the connection from client side.
 	conn.Close()

--- a/server/types/connection.go
+++ b/server/types/connection.go
@@ -10,8 +10,8 @@ import (
 // Connection represents one OpAMP connection.
 // The implementation MUST be a comparable type so that it can be used as a map key.
 type Connection interface {
-	// RemoteAddr returns the remote network address of the connection.
-	RemoteAddr() net.Addr
+	// Connection returns the underlying net.Conn
+	Connection() net.Conn
 
 	// Send a message. Should not be called concurrently for the same Connection instance.
 	// Can be called only for WebSocket connections. Will return an error for plain HTTP

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -18,8 +18,8 @@ type wsConnection struct {
 
 var _ types.Connection = (*wsConnection)(nil)
 
-func (c wsConnection) RemoteAddr() net.Addr {
-	return c.wsConn.RemoteAddr()
+func (c wsConnection) Connection() net.Conn {
+	return c.wsConn.UnderlyingConn()
 }
 
 // Message header is currently uint64 zero value.


### PR DESCRIPTION
I am implementing TLS in the example server and found that I need access to the underlying net.Conn. I added Connection() method to access it. Now that we have access to net.Conn, RemoteAddr() is no longer needed, it can be substituted by Connection().RemoteAddr().

Note: this is a breaking change.