### PR TITLE
wsclient closed network connection err check

### DIFF
--- a/client/internal/wsreceiver.go
+++ b/client/internal/wsreceiver.go
@@ -2,9 +2,12 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 
 	"github.com/gorilla/websocket"
+
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -49,7 +52,9 @@ out:
 	for {
 		var message protobufs.ServerToAgent
 		if err := r.receiveMessage(&message); err != nil {
-			if ctx.Err() == nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+			if ctx.Err() == nil &&
+				!websocket.IsCloseError(err, websocket.CloseNormalClosure) &&
+				!errors.Is(err, net.ErrClosed) {
 				r.logger.Errorf("Unexpected error while receiving: %v", err)
 			}
 			break out


### PR DESCRIPTION
This PR is to fix the issue https://github.com/open-telemetry/opamp-go/issues/163. 
When we try to ReadMessage on a closed connection, will through net.ErrClosed error. 

Tested this adding the following code 
https://github.com/open-telemetry/opamp-go/blob/main/client/wsclient.go#L243
`go func() {
		time.Sleep(5 * time.Second)
		c.Stop(ctx)
}()`
https://github.com/open-telemetry/opamp-go/blob/06011e4b754e9d41cbba7b5c166c6d2eec7b82d8/client/internal/wsreceiver.go#L65
`		time.Sleep(5 * time.Second)`

This allowed to close connection while the `receiveMessage` is in progress. 