### PR TITLE
changes to check ws connection close error

### DIFF
--- a/client/internal/wsreceiver.go
+++ b/client/internal/wsreceiver.go
@@ -2,9 +2,12 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 
 	"github.com/gorilla/websocket"
+
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -49,7 +52,9 @@ out:
 	for {
 		var message protobufs.ServerToAgent
 		if err := r.receiveMessage(&message); err != nil {
-			if ctx.Err() == nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+			if ctx.Err() == nil &&
+				!websocket.IsCloseError(err, websocket.CloseNormalClosure) &&
+				!errors.Is(err, net.ErrClosed) {
 				r.logger.Errorf("Unexpected error while receiving: %v", err)
 			}
 			break out

--- a/client/internal/wsreceiver_test.go
+++ b/client/internal/wsreceiver_test.go
@@ -3,10 +3,8 @@ package internal
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -22,11 +20,6 @@ type TestLogger struct {
 
 func (logger TestLogger) Debugf(format string, v ...interface{}) {
 	logger.Logf(format, v...)
-}
-
-func (logger TestLogger) Errorf(format string, v ...interface{}) {
-	err := fmt.Sprintf(format, v...)
-	logger.T.Errorf("unexpected error found: %s", err)
 }
 
 type commandAction int
@@ -148,19 +141,4 @@ func TestDecodeMessage(t *testing.T) {
 			assert.True(t, proto.Equal(msg, &decoded))
 		}
 	}
-}
-
-func TestWSReceiverReceiverLoop(t *testing.T) {
-	ctx := context.Background()
-	// Start a Server.
-	srv := StartMockServer(t)
-	defer srv.Close()
-	dialer := *websocket.DefaultDialer
-	conn, _, err := dialer.DialContext(ctx, "ws://"+srv.Endpoint, make(http.Header))
-	assert.NotNil(t, conn)
-	assert.NoError(t, err)
-	err = conn.Close()
-	assert.NoError(t, err)
-	receiver := NewWSReceiver(TestLogger{t}, nil, conn, nil, nil, nil, 0)
-	receiver.ReceiverLoop(ctx)
 }

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -82,11 +81,12 @@ func TestDisconnectWSByClient(t *testing.T) {
 	var settings types.StartSettings
 	settings.OpAMPServerURL = "ws://" + srv.Endpoint
 	client := NewWebSocket(TestLogger{t})
+	done := make(chan struct{})
 	go func() {
-		time.Sleep(1 * time.Second)
 		startClient(t, settings, client)
+		done <- struct{}{}
 	}()
-	time.Sleep(2 * time.Second)
+	eventually(t, func() bool { <-done; return true })
 	_ = client.Stop(context.Background())
 }
 

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -17,15 +17,15 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
-type TestLogger struct {
+type testLogger struct {
 	*testing.T
 }
 
-func (logger TestLogger) Debugf(format string, v ...interface{}) {
+func (logger testLogger) Debugf(format string, v ...interface{}) {
 	logger.Logf(format, v...)
 }
 
-func (logger TestLogger) Errorf(format string, v ...interface{}) {
+func (logger testLogger) Errorf(format string, v ...interface{}) {
 	err := fmt.Sprintf(format, v...)
 	logger.T.Errorf("unexpected error found: %s", err)
 }
@@ -80,7 +80,7 @@ func TestDisconnectWSByClient(t *testing.T) {
 
 	var settings types.StartSettings
 	settings.OpAMPServerURL = "ws://" + srv.Endpoint
-	client := NewWebSocket(TestLogger{t})
+	client := NewWebSocket(testLogger{t})
 	done := make(chan struct{})
 	go func() {
 		startClient(t, settings, client)


### PR DESCRIPTION
This PR is to fix the issue https://github.com/open-telemetry/opamp-go/issues/163.
When we try to ReadMessage on a closed connection, will through net.ErrClosed error.

Tested this adding the following code
https://github.com/open-telemetry/opamp-go/blob/main/client/wsclient.go#L243
go func() { time.Sleep(5 * time.Second) c.Stop(ctx) }()

[opamp-go/client/internal/wsreceiver.go](https://github.com/open-telemetry/opamp-go/blob/06011e4b754e9d41cbba7b5c166c6d2eec7b82d8/client/internal/wsreceiver.go#L65)

Line 65 in [06011e4](https://github.com/open-telemetry/opamp-go/commit/06011e4b754e9d41cbba7b5c166c6d2eec7b82d8)
 _, bytes, err := r.conn.ReadMessage() 

		time.Sleep(5 * time.Second)

This allowed to close connection while the receiveMessage is in progress.