### PR TITLE
Update AgentDescription identifying attributes in tests

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -29,6 +29,24 @@ func createAgentDescr() *protobufs.AgentDescription {
 	agentDescr := &protobufs.AgentDescription{
 		IdentifyingAttributes: []*protobufs.KeyValue{
 			{
+				Key:   "service.name",
+				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "otelcol"}},
+			},
+			{
+				Key:   "service.namespace",
+				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "default"}},
+			},
+			{
+				Key:   "service.instance.id",
+				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "443e083c-b968-4428-a281-6867bd280e0d"}},
+			},
+			{
+				Key:   "service.version",
+				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "1.0.0"}},
+			},
+		},
+		NonIdentifyingAttributes: []*protobufs.KeyValue{
+			{
 				Key:   "host.name",
 				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "somehost"}},
 			},

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -70,10 +70,22 @@ func TestHTTPClientCompression(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, response.AgentDescription.IdentifyingAttributes, []*protobufs.KeyValue{
 			{
-				Key:   "host.name",
-				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "somehost"}},
-			}},
-		)
+				Key:   "service.name",
+				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "otelcol"}},
+			},
+			{
+				Key:   "service.namespace",
+				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "default"}},
+			},
+			{
+				Key:   "service.instance.id",
+				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "443e083c-b968-4428-a281-6867bd280e0d"}},
+			},
+			{
+				Key:   "service.version",
+				Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "1.0.0"}},
+			},
+		})
 		w.WriteHeader(http.StatusOK)
 	}
 


### PR DESCRIPTION
To avoid confusion for the people who read the tests. This commit updates the tests to use `service.*` as identifying attributes since `host.*` usually helps in understanding the host agent runs and won't necessarily be identifying attributes. 