### PR TITLE
PackagesStateProvider error message flexibility on UpdateContent

### DIFF
--- a/client/internal/packagessyncer.go
+++ b/client/internal/packagessyncer.go
@@ -276,11 +276,7 @@ func (s *packagesSyncer) downloadFile(ctx context.Context, pkgName string, file 
 	// TODO: either add a callback to verify file.Signature or pass the Signature
 	// as a parameter to UpdateContent.
 
-	err = s.localState.UpdateContent(ctx, pkgName, resp.Body, file.ContentHash)
-	if err != nil {
-		return fmt.Errorf("cannot download file from %s: %v", file.DownloadUrl, err)
-	}
-	return nil
+	return s.localState.UpdateContent(ctx, pkgName, resp.Body, file.ContentHash)
 }
 
 // deleteUnneededLocalPackages deletes local packages that are not


### PR DESCRIPTION
This PR provides more flexibly for the PackagesStateProvider interface implementer to format and handle the error message on UpdateContent call. 

PR for Issue: https://github.com/open-telemetry/opamp-go/issues/175  