### PR TITLE
Allow setting polling interval for httpClient

### DIFF
--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"time"
 
 	"github.com/open-telemetry/opamp-go/client/internal"
 	"github.com/open-telemetry/opamp-go/client/types"
@@ -50,10 +51,6 @@ func (c *httpClient) Start(ctx context.Context, settings types.StartSettings) er
 
 	if settings.EnableCompression {
 		c.sender.EnableCompression()
-	}
-
-	if settings.PollingIntervalMs != nil {
-		c.sender.SetPollingInterval(*settings.PollingIntervalMs)
 	}
 
 	// Prepare the first message to send.
@@ -116,4 +113,8 @@ func (c *httpClient) runUntilStopped(ctx context.Context) {
 		c.common.PackagesStateProvider,
 		c.common.Capabilities,
 	)
+}
+
+func (c *httpClient) SetPollingInterval(duration time.Duration) {
+	c.sender.SetPollingInterval(duration)
 }

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -52,6 +52,10 @@ func (c *httpClient) Start(ctx context.Context, settings types.StartSettings) er
 		c.sender.EnableCompression()
 	}
 
+	if settings.PollingIntervalMs != nil {
+		c.sender.SetPollingInterval(*settings.PollingIntervalMs)
+	}
+
 	// Prepare the first message to send.
 	err := c.common.PrepareFirstMessage(ctx)
 	if err != nil {

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -111,7 +111,7 @@ func TestHTTPClientSetPollingInterval(t *testing.T) {
 	settings := types.StartSettings{}
 	settings.OpAMPServerURL = "http://" + srv.Endpoint
 	client := NewHTTP(nil)
-	client.SetPollingInterval(101 * time.Millisecond)
+	client.SetPollingInterval(100 * time.Millisecond)
 	prepareClient(t, &settings, client)
 
 	assert.NoError(t, client.Start(context.Background(), settings))

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -108,14 +108,10 @@ func TestHTTPClientSetPollingInterval(t *testing.T) {
 	}
 
 	// Start a client.
-	settings := types.StartSettings{
-		PollingIntervalMs: func() *time.Duration {
-			tms := 101 * time.Millisecond
-			return &tms
-		}(),
-	}
+	settings := types.StartSettings{}
 	settings.OpAMPServerURL = "http://" + srv.Endpoint
 	client := NewHTTP(nil)
+	client.SetPollingInterval(101 * time.Millisecond)
 	prepareClient(t, &settings, client)
 
 	assert.NoError(t, client.Start(context.Background(), settings))

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/open-telemetry/opamp-go/client/internal"
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestHTTPPolling(t *testing.T) {
@@ -90,6 +91,45 @@ func TestHTTPClientCompression(t *testing.T) {
 
 	srv.Close()
 
+	err := client.Stop(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestHTTPClientSetPollingInterval(t *testing.T) {
+	// Start a Server.
+	srv := internal.StartMockServer(t)
+	var rcvCounter int64
+	srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		assert.EqualValues(t, rcvCounter, msg.SequenceNum)
+		if msg != nil {
+			atomic.AddInt64(&rcvCounter, 1)
+		}
+		return nil
+	}
+
+	// Start a client.
+	settings := types.StartSettings{
+		PollingIntervalMs: func() *time.Duration {
+			tms := 101 * time.Millisecond
+			return &tms
+		}(),
+	}
+	settings.OpAMPServerURL = "http://" + srv.Endpoint
+	client := NewHTTP(nil)
+	prepareClient(t, &settings, client)
+
+	assert.NoError(t, client.Start(context.Background(), settings))
+
+	// Verify that status report is delivered.
+	eventually(t, func() bool { return atomic.LoadInt64(&rcvCounter) == 1 })
+
+	// Verify that status report is delivered again. no call is made for next 100ms
+	assert.Eventually(t, func() bool { return atomic.LoadInt64(&rcvCounter) == 2 }, 5*time.Second, 100*time.Millisecond)
+
+	// Shutdown the Server.
+	srv.Close()
+
+	// Shutdown the client.
 	err := client.Stop(context.Background())
 	assert.NoError(t, err)
 }

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -3,7 +3,6 @@ package types
 import (
 	"crypto/tls"
 	"net/http"
-	"time"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
@@ -49,8 +48,4 @@ type StartSettings struct {
 	// the compression is only effectively enabled if the Server also supports compression.
 	// The data will be compressed in both directions.
 	EnableCompression bool
-
-	// Optional PollingIntervalMs to configure the polling interval for http client
-	// if nil uses the default polling interval else uses this value.
-	PollingIntervalMs *time.Duration
 }

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -3,6 +3,7 @@ package types
 import (
 	"crypto/tls"
 	"net/http"
+	"time"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
@@ -48,4 +49,8 @@ type StartSettings struct {
 	// the compression is only effectively enabled if the Server also supports compression.
 	// The data will be compressed in both directions.
 	EnableCompression bool
+
+	// Optional PollingIntervalMs to configure the polling interval for http client
+	// if nil uses the default polling interval else uses this value.
+	PollingIntervalMs *time.Duration
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opamp-go/issues/176