### PR TITLE
Fix supervisor example to work with TLS

### DIFF
--- a/internal/examples/supervisor/bin/supervisor.yaml
+++ b/internal/examples/supervisor/bin/supervisor.yaml
@@ -1,5 +1,5 @@
 server:
-  endpoint: ws://127.0.0.1:4320/v1/opamp
+  endpoint: wss://127.0.0.1:4320/v1/opamp
 
 agent:
   executable: ../../../../../opentelemetry-collector-contrib/bin/otelcontribcol_darwin_amd64

--- a/internal/examples/supervisor/supervisor/supervisor.go
+++ b/internal/examples/supervisor/supervisor/supervisor.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -17,6 +18,7 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/rawbytes"
 	"github.com/oklog/ulid/v2"
+
 	"github.com/open-telemetry/opamp-go/client"
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/internal/examples/supervisor/supervisor/commander"
@@ -133,7 +135,10 @@ func (s *Supervisor) startOpAMP() error {
 
 	settings := types.StartSettings{
 		OpAMPServerURL: s.config.Server.Endpoint,
-		InstanceUid:    s.instanceId.String(),
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+		InstanceUid: s.instanceId.String(),
 		Callbacks: types.CallbacksStruct{
 			OnConnectFunc: func() {
 				s.logger.Debugf("Connected to the server.")


### PR DESCRIPTION
https://github.com/open-telemetry/opamp-go/pull/174 enabled TLS on the server and non-TLS connections are no longer accepted.

This PR updates the Supervisor to use TLS connection (with InsecureSkipVerify=true flag).