### PR TITLE
Add support for client-initiated connection settings request

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -80,4 +80,13 @@ type OpAMPClient interface {
 	// May be called anytime after Start(), including from OnMessage handler.
 	// nil values are not allowed and will return an error.
 	SetPackageStatuses(statuses *protobufs.PackageStatuses) error
+
+	// RequestConnectionSettings sets a ConnectionSettingsRequest. The ConnectionSettingsRequest
+	// will be included in the next AgentToServer message sent to the Server.
+	// Used for client-initiated connection setting acquisition flows.
+	// It is the responsibility of the caller to ensure that the Server supports
+	// AcceptsConnectionSettingsRequest capability.
+	// May be called before or after Start().
+	// May be also called from OnMessage handler.
+	RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error
 }

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -81,6 +81,10 @@ func (c *httpClient) SetAgentDescription(descr *protobufs.AgentDescription) erro
 	return c.common.SetAgentDescription(descr)
 }
 
+func (c *httpClient) RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error {
+	return c.common.RequestConnectionSettings(request)
+}
+
 // SetHealth implements OpAMPClient.SetHealth.
 func (c *httpClient) SetHealth(health *protobufs.ComponentHealth) error {
 	return c.common.SetHealth(health)

--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -243,6 +243,16 @@ func (c *ClientCommon) SetAgentDescription(descr *protobufs.AgentDescription) er
 	return nil
 }
 
+func (c *ClientCommon) RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error {
+	c.sender.NextMessage().Update(
+		func(msg *protobufs.AgentToServer) {
+			msg.ConnectionSettingsRequest = request
+		},
+	)
+	c.sender.ScheduleSend()
+	return nil
+}
+
 // SetHealth sends a status update to the Server with the new agent health
 // and remembers the health in the client state so that it can be sent
 // to the Server when the Server asks for it.

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -100,6 +100,10 @@ func (c *wsClient) SetAgentDescription(descr *protobufs.AgentDescription) error 
 	return c.common.SetAgentDescription(descr)
 }
 
+func (c *wsClient) RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error {
+	return c.common.RequestConnectionSettings(request)
+}
+
 func (c *wsClient) SetHealth(health *protobufs.ComponentHealth) error {
 	return c.common.SetHealth(health)
 }

--- a/internal/examples/server/certman/certman.go
+++ b/internal/examples/server/certman/certman.go
@@ -1,0 +1,153 @@
+package certman
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/big"
+	"net"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+var logger = log.New(log.Default().Writer(), "[CertMan] ", log.Default().Flags()|log.Lmsgprefix|log.Lmicroseconds)
+
+var caCert *x509.Certificate
+var caPrivKey *rsa.PrivateKey
+var caCertBytes []byte
+
+var loadCACertOnce sync.Once
+
+func loadCACert() {
+	certsDir := "../../certs"
+
+	// Load CA certificate.
+	var err error
+	caCertBytes, err = ioutil.ReadFile(path.Join(certsDir, "certs/ca.cert.pem"))
+	if err != nil {
+		logger.Fatalf("Cannot read CA cert: %v", err)
+	}
+
+	caKeyBytes, err := ioutil.ReadFile(path.Join(certsDir, "private/ca.key.pem"))
+	if err != nil {
+		logger.Fatalf("Cannot read CA key: %v", err)
+	}
+
+	// Convert from DER to PEM format.
+	caCertPB, _ := pem.Decode(caCertBytes)
+	caKeyPB, _ := pem.Decode(caKeyBytes)
+
+	caCert, err = x509.ParseCertificate(caCertPB.Bytes)
+	if err != nil {
+		logger.Fatalf("Cannot parse CA certificate: %v", err)
+	}
+
+	caPrivKey, err = x509.ParsePKCS1PrivateKey(caKeyPB.Bytes)
+	if err != nil {
+		logger.Fatalf("Cannot parse CA key: %v", err)
+	}
+}
+
+func createClientTLSCertTemplate() *x509.Certificate {
+	return &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour * 1000),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+}
+
+func CreateClientTLSCertFromCSR(csr *x509.CertificateRequest) (*protobufs.TLSCertificate, error) {
+	loadCACertOnce.Do(loadCACert)
+
+	template := createClientTLSCertTemplate()
+
+	// Use the Subject from CSR.
+	template.Subject = csr.Subject
+
+	// Create the client cert and sign it using CA cert.
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, csr.PublicKey, caPrivKey)
+	if err != nil {
+		err := fmt.Errorf("cannot create certificate: %v", err)
+		return nil, err
+	}
+
+	// Convert from DER to PEM format.
+	certPEM := new(bytes.Buffer)
+	pem.Encode(
+		certPEM, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certBytes,
+		},
+	)
+
+	// We have a client certificate with a public and private key.
+	certificate := &protobufs.TLSCertificate{
+		PublicKey:   certPEM.Bytes(),
+		CaPublicKey: caCertBytes,
+	}
+
+	return certificate, nil
+}
+
+func CreateClientTLSCert() (*protobufs.TLSCertificate, error) {
+	loadCACertOnce.Do(loadCACert)
+
+	// Generate a keypair for new client cert.
+	clientCertKeyPair, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		err := fmt.Errorf("cannot generate keypair: %v", err)
+		return nil, err
+	}
+
+	// Prepare certificate template.
+	template := createClientTLSCertTemplate()
+	template.Subject = pkix.Name{
+		CommonName:   "OpAMP Example Client",
+		Organization: []string{"OpenTelemetry OpAMP Workgroup"},
+		Locality:     []string{"Server-initiated"},
+	}
+
+	// Create the client cert. Sign it using CA cert.
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &clientCertKeyPair.PublicKey, caPrivKey)
+	if err != nil {
+		err := fmt.Errorf("cannot create certificate: %v", err)
+		return nil, err
+	}
+
+	certPEM := new(bytes.Buffer)
+	pem.Encode(
+		certPEM, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certDER,
+		},
+	)
+
+	privateKeyPEM := new(bytes.Buffer)
+	pem.Encode(
+		privateKeyPEM, &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(clientCertKeyPair),
+		},
+	)
+
+	// We have a client certificate with a public and private key.
+	certificate := &protobufs.TLSCertificate{
+		PublicKey:   certPEM.Bytes(),
+		PrivateKey:  privateKeyPEM.Bytes(),
+		CaPublicKey: caCertBytes,
+	}
+
+	return certificate, nil
+}

--- a/internal/examples/server/uisrv/ui.go
+++ b/internal/examples/server/uisrv/ui.go
@@ -121,7 +121,7 @@ func rotateInstanceClientCert(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a new certificate for the agent.
-	certificate, err := internal.CreateTLSCert("../../certs/certs/ca.cert.pem", "../../certs/certs/ca.key.pem")
+	certificate, err := internal.CreateTLSCert("../../certs/certs/ca.cert.pem", "../../certs/private/ca.key.pem")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		logger.Println(err)


### PR DESCRIPTION
- Implemented spec change https://github.com/open-telemetry/opamp-spec/pull/162
- Added ability for the client to request connection settings.
- Added CSR flow example to demonstrate the new capability.