### PR TITLE
Rewind the request body for retries

### DIFF
--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -157,7 +157,6 @@ func TestHTTPSenderRetryForFailedRequests(t *testing.T) {
 		wg.Done()
 	}()
 	go func() {
-		time.Sleep(200 * time.Millisecond)
 		l, err := net.Listen("tcp", address)
 		assert.NoError(t, err)
 		ts := httptest.NewUnstartedServer(m)


### PR DESCRIPTION
Fixes #193 

`prepareRequest` in HTTP Sender returns a `http.Request` https://github.com/open-telemetry/opamp-go/blob/deb33889ff1aac0d542a9fd08f946461cccfc1c7/client/internal/httpsender.go#L201 
We have the backoff retry strategy for failed requests; however, underlying transport would close the request body and should be rewound for any subsequent attempt. This creates a thin wrapper around the `http.Request` that helps to rewind the body before making a request. We hijack and close the underlying connection to simulate the connection error case.