### PR TITLE
Avoid spurious error log for Client.Stop closed connections

### DIFF
--- a/client/internal/wsreceiver.go
+++ b/client/internal/wsreceiver.go
@@ -2,7 +2,9 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 
 	"github.com/gorilla/websocket"
 	"github.com/open-telemetry/opamp-go/client/types"
@@ -49,7 +51,7 @@ out:
 	for {
 		var message protobufs.ServerToAgent
 		if err := r.receiveMessage(&message); err != nil {
-			if ctx.Err() == nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+			if ctx.Err() == nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) && !errors.Is(err, net.ErrClosed) {
 				r.logger.Errorf("Unexpected error while receiving: %v", err)
 			}
 			break out

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -123,12 +123,6 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (retryAfter sharedinterna
 	var resp *http.Response
 	conn, resp, err := c.dialer.DialContext(ctx, c.url.String(), c.requestHeader)
 	if err != nil {
-		// `DailContext` returns a mapped error for any context error, we remap it
-		// to the original context error.
-		// See https://github.com/golang/go/blob/561a5079057e3a660ab638e1ba957a96c4ff3fd1/src/net/net.go#L424-L435
-		if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
-			err = ctx.Err()
-		}
 		if c.common.Callbacks != nil && !c.common.IsStopping() {
 			c.common.Callbacks.OnConnectFailed(err)
 		}


### PR DESCRIPTION
Co-authored-by: phanidevavarapu

This is a continuation of closed PR https://github.com/open-telemetry/opamp-go/pull/173. Fixes #163 