### PR TITLE
Gracefully close websocket connections from the client

### DIFF
--- a/client/internal/nextmessage.go
+++ b/client/internal/nextmessage.go
@@ -34,13 +34,6 @@ func (s *NextMessage) Update(modifier func(msg *protobufs.AgentToServer)) {
 	s.messageMutex.Unlock()
 }
 
-// IsPending returns whether there is a pending message to be sent.
-func (s *NextMessage) IsPending() bool {
-	s.messageMutex.Lock()
-	defer s.messageMutex.Unlock()
-	return s.messagePending
-}
-
 // PopPending returns the next message to be sent, if it is pending or nil otherwise.
 // Clears the "pending" flag.
 func (s *NextMessage) PopPending() *protobufs.AgentToServer {

--- a/client/internal/nextmessage.go
+++ b/client/internal/nextmessage.go
@@ -34,6 +34,13 @@ func (s *NextMessage) Update(modifier func(msg *protobufs.AgentToServer)) {
 	s.messageMutex.Unlock()
 }
 
+// IsPending returns whether there is a pending message to be sent.
+func (s *NextMessage) IsPending() bool {
+	s.messageMutex.Lock()
+	defer s.messageMutex.Unlock()
+	return s.messagePending
+}
+
 // PopPending returns the next message to be sent, if it is pending or nil otherwise.
 // Clears the "pending" flag.
 func (s *NextMessage) PopPending() *protobufs.AgentToServer {

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -37,6 +37,8 @@ type wsClient struct {
 	sender *internal.WSSender
 }
 
+var _ OpAMPClient = &wsClient{}
+
 // NewWebSocket creates a new OpAMP Client that uses WebSocket transport.
 func NewWebSocket(logger types.Logger) *wsClient {
 	if logger == nil {

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -246,6 +246,7 @@ func TestHandlesSlowCloseMessageFromServer(t *testing.T) {
 	}
 
 	client := NewWebSocket(nil)
+	client.connShutdownTimeout = 100 * time.Millisecond
 	startClient(t, types.StartSettings{
 		OpAMPServerURL: srv.GetHTTPTestServer().URL,
 	}, client)
@@ -268,7 +269,7 @@ func TestHandlesSlowCloseMessageFromServer(t *testing.T) {
 	wsConn.SetCloseHandler(func(code int, _ string) error {
 		require.Equal(t, websocket.CloseNormalClosure, code, "Client sent non-normal closing code")
 
-		time.Sleep(4 * time.Second)
+		time.Sleep(200 * time.Millisecond)
 		err := defHandler(code, "")
 		closed <- struct{}{}
 		return err
@@ -278,7 +279,7 @@ func TestHandlesSlowCloseMessageFromServer(t *testing.T) {
 
 	select {
 	case <-closed:
-	case <-time.After(2 * time.Second):
+	case <-time.After(1 * time.Second):
 		require.Fail(t, "Connection never closed")
 	}
 }
@@ -295,6 +296,7 @@ func TestHandlesNoCloseMessageFromServer(t *testing.T) {
 	}
 
 	client := NewWebSocket(nil)
+	client.connShutdownTimeout = 100 * time.Millisecond
 	startClient(t, types.StartSettings{
 		OpAMPServerURL: srv.GetHTTPTestServer().URL,
 	}, client)
@@ -324,7 +326,7 @@ func TestHandlesNoCloseMessageFromServer(t *testing.T) {
 
 	select {
 	case <-closed:
-	case <-time.After(5 * time.Second):
+	case <-time.After(1 * time.Second):
 		require.Fail(t, "Connection never closed")
 	}
 }

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -203,7 +203,10 @@ func TestPerformsClosingHandshake(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
-		return client.conn != nil
+		client.connMutex.RLock()
+		conn := client.conn
+		client.connMutex.RUnlock()
+		return conn != nil
 	}, 2*time.Second, 250*time.Millisecond)
 
 	defHandler := wsConn.CloseHandler()
@@ -248,7 +251,10 @@ func TestHandlesNoCloseMessageFromServer(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
-		return client.conn != nil
+		client.connMutex.RLock()
+		conn := client.conn
+		client.connMutex.RUnlock()
+		return conn != nil
 	}, 2*time.Second, 250*time.Millisecond)
 
 	wsConn.SetCloseHandler(func(code int, _ string) error {

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/open-telemetry/opamp-go/client/internal"
@@ -175,5 +177,93 @@ func TestVerifyWSCompress(t *testing.T) {
 				assert.Greater(t, proxy.ClientToServerBytes(), len(uncompressedCfg))
 			}
 		})
+	}
+}
+
+func TestPerformsClosingHandshake(t *testing.T) {
+	srv := internal.StartMockServer(t)
+	var wsConn *websocket.Conn
+	connected := make(chan bool)
+	closed := make(chan bool)
+
+	srv.OnWSConnect = func(conn *websocket.Conn) {
+		wsConn = conn
+		connected <- true
+	}
+
+	client := NewWebSocket(nil)
+	startClient(t, types.StartSettings{
+		OpAMPServerURL: srv.GetHTTPTestServer().URL,
+	}, client)
+
+	select {
+	case <-connected:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Connection never established")
+	}
+
+	require.Eventually(t, func() bool {
+		return client.conn != nil
+	}, 2*time.Second, 250*time.Millisecond)
+
+	defHandler := wsConn.CloseHandler()
+
+	wsConn.SetCloseHandler(func(code int, _ string) error {
+		require.Equal(t, websocket.CloseNormalClosure, code, "Client sent non-normal closing code")
+
+		err := defHandler(code, "")
+		closed <- true
+		return err
+	})
+
+	client.Stop(context.Background())
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Connection never closed")
+	}
+}
+
+func TestHandlesNoCloseMessageFromServer(t *testing.T) {
+	srv := internal.StartMockServer(t)
+	var wsConn *websocket.Conn
+	connected := make(chan bool)
+	closed := make(chan bool)
+
+	srv.OnWSConnect = func(conn *websocket.Conn) {
+		wsConn = conn
+		connected <- true
+	}
+
+	client := NewWebSocket(nil)
+	startClient(t, types.StartSettings{
+		OpAMPServerURL: srv.GetHTTPTestServer().URL,
+	}, client)
+
+	select {
+	case <-connected:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Connection never established")
+	}
+
+	require.Eventually(t, func() bool {
+		return client.conn != nil
+	}, 2*time.Second, 250*time.Millisecond)
+
+	wsConn.SetCloseHandler(func(code int, _ string) error {
+		// Don't send close message
+		return nil
+	})
+
+	go func() {
+		client.Stop(context.Background())
+		closed <- true
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "Connection never closed")
 	}
 }

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -751,20 +751,12 @@ func TestConnectionAllowsConcurrentWrites(t *testing.T) {
 
 	defer conn.Close()
 
-	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	require.Eventually(t, func() bool {
+		return srvConnVal.Load() != nil
+	}, 2*time.Second, 250*time.Millisecond)
 
-	select {
-	case <-timeout.Done():
-		t.Error("Client failed to connect before timeout")
-	default:
-		if _, ok := srvConnVal.Load().(types.Connection); ok == true {
-			break
-		}
-	}
-
-	cancel()
-
-	srvConn := srvConnVal.Load().(types.Connection)
+	srvConn, ok := srvConnVal.Load().(types.Connection)
+	require.True(t, ok, "The server connection is not a types.Connection")
 	for i := 0; i < 20; i++ {
 		go func() {
 			defer func() {


### PR DESCRIPTION
On calling `OpAMPClient.Stop` for websocket clients, the client closes the TCP connection without performing a closing handshake, which from my testing throws a handful of errors in the client and the server.

This change attempts to gracefully close the connection by initiating a closing handshake [as specified](https://www.rfc-editor.org/rfc/rfc6455.html#section-7.1.2) in RFC 6455. This gives the connection on both sides time to clean up before terminating the TCP connection, and is more compliant with the Websocket specification.

Testing with the Supervisor, this cleans up the following errors in the client:

```
2023-09-20T16:16:42.018-0400    ERROR   internal/wssender.go:77 Cannot write WS message: use of closed network connection
github.com/open-telemetry/opamp-go/client/internal.(*WSSender).sendMessage
        /home/ihsmwaqhcpfwcime/code/github.com/evan-bradley/opamp-go/client/internal/wssender.go:77
github.com/open-telemetry/opamp-go/client/internal.(*WSSender).sendNextMessage
        /home/ihsmwaqhcpfwcime/code/github.com/evan-bradley/opamp-go/client/internal/wssender.go:70
github.com/open-telemetry/opamp-go/client/internal.(*WSSender).run
        /home/ihsmwaqhcpfwcime/code/github.com/evan-bradley/opamp-go/client/internal/wssender.go:56
```

```
2023-09-20T16:16:42.018-0400    ERROR   internal/wsreceiver.go:53       Unexpected error while receiving: read tcp 127.0.0.1:45242->127.0.0.1:4320: use of closed network connection
github.com/open-telemetry/opamp-go/client/internal.(*wsReceiver).ReceiverLoop
        /home/ihsmwaqhcpfwcime/code/github.com/evan-bradley/opamp-go/client/internal/wsreceiver.go:53
github.com/open-telemetry/opamp-go/client.(*wsClient).runOneCycle
        /home/ihsmwaqhcpfwcime/code/github.com/evan-bradley/opamp-go/client/wsclient.go:243
github.com/open-telemetry/opamp-go/client.(*wsClient).runUntilStopped
        /home/ihsmwaqhcpfwcime/code/github.com/evan-bradley/opamp-go/client/wsclient.go:265
github.com/open-telemetry/opamp-go/client/internal.(*ClientCommon).StartConnectAndRun.func1
        /home/ihsmwaqhcpfwcime/code/github.com/evan-bradley/opamp-go/client/internal/clientcommon.go:199
```

This also cleans up the following error in the server that I have seen while running tests:
```
Cannot send message to WebSocket: write tcp 127.0.0.1:42589->127.0.0.1:48774: write: connection reset by peer
```