### PR TITLE
Fix set invalid instance UID error throw

### DIFF
--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -217,7 +217,7 @@ func (r *receivedProcessor) rcvAgentIdentification(agentId *protobufs.AgentIdent
 
 	err := r.sender.SetInstanceUid(agentId.NewInstanceUid)
 	if err != nil {
-		r.logger.Errorf("error while setting instance uid: %v", err)
+		r.logger.Errorf("Error while setting instance uid: %v", err)
 		return err
 	}
 

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -217,7 +217,7 @@ func (r *receivedProcessor) rcvAgentIdentification(agentId *protobufs.AgentIdent
 
 	err := r.sender.SetInstanceUid(agentId.NewInstanceUid)
 	if err != nil {
-		r.logger.Errorf("Error while setting instance uid: %v, err")
+		r.logger.Errorf("error while setting instance uid: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
Fixing error throw logger when setting invalid instance UID provided by the server.