### PR TITLE
Change callback signatures to pass down context where applicable

### DIFF
--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -129,7 +129,7 @@ func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *pro
 		}
 
 		if msg.AgentIdentification != nil {
-			err := r.rcvAgentIdentification(msg.AgentIdentification)
+			err := r.rcvAgentIdentification(ctx, msg.AgentIdentification)
 			if err == nil {
 				msgData.AgentIdentification = msg.AgentIdentification
 			}
@@ -146,7 +146,7 @@ func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *pro
 
 	err := msg.GetErrorResponse()
 	if err != nil {
-		r.processErrorResponse(err)
+		r.processErrorResponse(ctx, err)
 	}
 }
 
@@ -203,21 +203,21 @@ func (r *receivedProcessor) rcvOpampConnectionSettings(ctx context.Context, sett
 	}
 }
 
-func (r *receivedProcessor) processErrorResponse(body *protobufs.ServerErrorResponse) {
+func (r *receivedProcessor) processErrorResponse(ctx context.Context, body *protobufs.ServerErrorResponse) {
 	// TODO: implement this.
-	r.logger.Errorf(context.Background(), "received an error from server: %s", body.ErrorMessage)
+	r.logger.Errorf(ctx, "received an error from server: %s", body.ErrorMessage)
 }
 
-func (r *receivedProcessor) rcvAgentIdentification(agentId *protobufs.AgentIdentification) error {
+func (r *receivedProcessor) rcvAgentIdentification(ctx context.Context, agentId *protobufs.AgentIdentification) error {
 	if agentId.NewInstanceUid == "" {
 		err := errors.New("empty instance uid is not allowed")
-		r.logger.Debugf(context.Background(), err.Error())
+		r.logger.Debugf(ctx, err.Error())
 		return err
 	}
 
 	err := r.sender.SetInstanceUid(agentId.NewInstanceUid)
 	if err != nil {
-		r.logger.Errorf(context.Background(), "Error while setting instance uid: %v", err)
+		r.logger.Errorf(ctx, "Error while setting instance uid: %v", err)
 		return err
 	}
 

--- a/internal/examples/agent/agent/agent.go
+++ b/internal/examples/agent/agent/agent.go
@@ -160,9 +160,9 @@ func (agent *Agent) connect() error {
 	return nil
 }
 
-func (agent *Agent) disconnect() {
-	agent.logger.Debugf(context.Background(), "Disconnecting from server...")
-	agent.opampClient.Stop(context.Background())
+func (agent *Agent) disconnect(ctx context.Context) {
+	agent.logger.Debugf(ctx, "Disconnecting from server...")
+	agent.opampClient.Stop(ctx)
 }
 
 func (agent *Agent) createAgentIdentity() {
@@ -209,8 +209,8 @@ func (agent *Agent) createAgentIdentity() {
 	}
 }
 
-func (agent *Agent) updateAgentIdentity(instanceId ulid.ULID) {
-	agent.logger.Debugf(context.Background(), "Agent identify is being changed from id=%v to id=%v",
+func (agent *Agent) updateAgentIdentity(ctx context.Context, instanceId ulid.ULID) {
+	agent.logger.Debugf(ctx, "Agent identify is being changed from id=%v to id=%v",
 		agent.instanceId.String(),
 		instanceId.String())
 	agent.instanceId = instanceId
@@ -463,13 +463,13 @@ func (agent *Agent) onMessage(ctx context.Context, msg *types.MessageData) {
 		if err != nil {
 			agent.logger.Errorf(ctx, err.Error())
 		}
-		agent.updateAgentIdentity(newInstanceId)
+		agent.updateAgentIdentity(ctx, newInstanceId)
 	}
 
 	if configChanged {
 		err := agent.opampClient.UpdateEffectiveConfig(ctx)
 		if err != nil {
-			agent.logger.Errorf(context.Background(), err.Error())
+			agent.logger.Errorf(ctx, err.Error())
 		}
 	}
 
@@ -486,7 +486,7 @@ func (agent *Agent) onMessage(ctx context.Context, msg *types.MessageData) {
 func (agent *Agent) tryChangeOpAMPCert(ctx context.Context, cert *tls.Certificate) {
 	agent.logger.Debugf(ctx, "Reconnecting to verify offered client certificate.\n")
 
-	agent.disconnect()
+	agent.disconnect(ctx)
 
 	agent.opampClientCert = cert
 	if err := agent.connect(); err != nil {

--- a/internal/examples/server/opampsrv/opampsrv.go
+++ b/internal/examples/server/opampsrv/opampsrv.go
@@ -79,7 +79,7 @@ func (srv *Server) onDisconnect(conn types.Connection) {
 	srv.agents.RemoveConnection(conn)
 }
 
-func (srv *Server) onMessage(conn types.Connection, msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+func (srv *Server) onMessage(ctx context.Context, conn types.Connection, msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 	instanceId := data.InstanceId(msg.InstanceUid)
 
 	agent := srv.agents.FindOrCreateAgent(instanceId, conn)

--- a/server/callbacks.go
+++ b/server/callbacks.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -27,25 +28,25 @@ func (c CallbacksStruct) OnConnecting(request *http.Request) types.ConnectionRes
 // ConnectionCallbacksStruct is a struct that implements ConnectionCallbacks interface and allows
 // to override only the methods that are needed.
 type ConnectionCallbacksStruct struct {
-	OnConnectedFunc       func(conn types.Connection)
-	OnMessageFunc         func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent
+	OnConnectedFunc       func(ctx context.Context, conn types.Connection)
+	OnMessageFunc         func(ctx context.Context, conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent
 	OnConnectionCloseFunc func(conn types.Connection)
 }
 
 var _ types.ConnectionCallbacks = (*ConnectionCallbacksStruct)(nil)
 
 // OnConnected implements ConnectionCallbacks.OnConnected.
-func (c ConnectionCallbacksStruct) OnConnected(conn types.Connection) {
+func (c ConnectionCallbacksStruct) OnConnected(ctx context.Context, conn types.Connection) {
 	if c.OnConnectedFunc != nil {
-		c.OnConnectedFunc(conn)
+		c.OnConnectedFunc(ctx, conn)
 	}
 }
 
 // OnMessage implements ConnectionCallbacks.OnMessage.
 // If OnMessageFunc is nil then it will send an empty response to the agent
-func (c ConnectionCallbacksStruct) OnMessage(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+func (c ConnectionCallbacksStruct) OnMessage(ctx context.Context, conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 	if c.OnMessageFunc != nil {
-		return c.OnMessageFunc(conn, message)
+		return c.OnMessageFunc(ctx, conn, message)
 	} else {
 		// We will send an empty response since there is no user-defined callback to handle it.
 		return &protobufs.ServerToAgent{

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -137,7 +137,7 @@ func TestServerStartAcceptConnection(t *testing.T) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-				OnConnectedFunc: func(conn types.Connection) {
+				OnConnectedFunc: func(ctx context.Context, conn types.Connection) {
 					srvConn = conn
 					atomic.StoreInt32(&connectedCalled, 1)
 				},
@@ -225,7 +225,7 @@ func TestServerReceiveSendMessage(t *testing.T) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-				OnMessageFunc: func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				OnMessageFunc: func(ctx context.Context, conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 					// Remember received message.
 					rcvMsg.Store(message)
 
@@ -292,7 +292,7 @@ func TestServerReceiveSendMessageWithCompression(t *testing.T) {
 			callbacks := CallbacksStruct{
 				OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 					return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-						OnMessageFunc: func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+						OnMessageFunc: func(ctx context.Context, conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 							// Remember received message.
 							rcvMsg.Store(message)
 
@@ -390,10 +390,10 @@ func TestServerReceiveSendMessagePlainHTTP(t *testing.T) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-				OnConnectedFunc: func(conn types.Connection) {
+				OnConnectedFunc: func(ctx context.Context, conn types.Connection) {
 					atomic.StoreInt32(&onConnectedCalled, 1)
 				},
-				OnMessageFunc: func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				OnMessageFunc: func(ctx context.Context, conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 					// Remember received message.
 					rcvMsg.Store(message)
 
@@ -458,7 +458,7 @@ func TestServerAttachAcceptConnection(t *testing.T) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-				OnConnectedFunc: func(conn types.Connection) {
+				OnConnectedFunc: func(ctx context.Context, conn types.Connection) {
 					atomic.StoreInt32(&connectedCalled, 1)
 					srvConn = conn
 				},
@@ -508,11 +508,11 @@ func TestServerAttachSendMessagePlainHTTP(t *testing.T) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-				OnConnectedFunc: func(conn types.Connection) {
+				OnConnectedFunc: func(ctx context.Context, conn types.Connection) {
 					atomic.StoreInt32(&connectedCalled, 1)
 					srvConn = conn
 				},
-				OnMessageFunc: func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				OnMessageFunc: func(ctx context.Context, conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 					// Remember received message.
 					rcvMsg.Store(message)
 
@@ -590,10 +590,10 @@ func TestServerHonoursClientRequestContentEncoding(t *testing.T) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-				OnConnectedFunc: func(conn types.Connection) {
+				OnConnectedFunc: func(ctx context.Context, conn types.Connection) {
 					atomic.StoreInt32(&onConnectedCalled, 1)
 				},
-				OnMessageFunc: func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				OnMessageFunc: func(ctx context.Context, conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 					// Remember received message.
 					rcvMsg.Store(message)
 
@@ -667,10 +667,10 @@ func TestServerHonoursAcceptEncoding(t *testing.T) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-				OnConnectedFunc: func(conn types.Connection) {
+				OnConnectedFunc: func(ctx context.Context, conn types.Connection) {
 					atomic.StoreInt32(&onConnectedCalled, 1)
 				},
-				OnMessageFunc: func(conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				OnMessageFunc: func(ctx context.Context, conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 					// Remember received message.
 					rcvMsg.Store(message)
 
@@ -772,7 +772,7 @@ func TestConnectionAllowsConcurrentWrites(t *testing.T) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-				OnConnectedFunc: func(conn types.Connection) {
+				OnConnectedFunc: func(ctx context.Context, conn types.Connection) {
 					srvConnVal.Store(conn)
 				},
 			}}
@@ -827,7 +827,7 @@ func BenchmarkSendToClient(b *testing.B) {
 	callbacks := CallbacksStruct{
 		OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 			return types.ConnectionResponse{Accept: true, ConnectionCallbacks: ConnectionCallbacksStruct{
-				OnConnectedFunc: func(conn types.Connection) {
+				OnConnectedFunc: func(ctx context.Context, conn types.Connection) {
 					srvConnectionsMutex.Lock()
 					serverConnections = append(serverConnections, conn)
 					srvConnectionsMutex.Unlock()

--- a/server/types/callbacks.go
+++ b/server/types/callbacks.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -38,16 +39,16 @@ type ConnectionCallbacks interface {
 	// The following callbacks will never be called concurrently for the same
 	// connection. They may be called concurrently for different connections.
 
-	// OnConnected is called when and incoming OpAMP connection is successfully
+	// OnConnected is called when an incoming OpAMP connection is successfully
 	// established after OnConnecting() returns.
-	OnConnected(conn Connection)
+	OnConnected(ctx context.Context, conn Connection)
 
 	// OnMessage is called when a message is received from the connection. Can happen
 	// only after OnConnected(). Must return a ServerToAgent message that will be sent
 	// as a response to the Agent.
 	// For plain HTTP requests once OnMessage returns and the response is sent
 	// to the Agent the OnConnectionClose message will be called immediately.
-	OnMessage(conn Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent
+	OnMessage(ctx context.Context, conn Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent
 
 	// OnConnectionClose is called when the OpAMP connection is closed.
 	OnConnectionClose(conn Connection)


### PR DESCRIPTION
Changes a few server callback interface methods to pass down a context to propagate request information effectively. This closes #214 