### PR TITLE
Follow HTTP redirects after failed WS dials

### DIFF
--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -141,7 +141,8 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (err error, retryAfter sh
 					c.common.Logger.Errorf(ctx, "%d redirect, but no valid location: %s", resp.StatusCode, err)
 					return err, duration
 				}
-				if redirect.Scheme == "http" || redirect.Scheme == "" {
+				// rewrite the scheme for the sake of tolerance
+				if redirect.Scheme == "http" {
 					redirect.Scheme = "ws"
 				} else if redirect.Scheme == "https" {
 					redirect.Scheme = "wss"

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -136,6 +137,7 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (err error, retryAfter sh
 				// very liberal handling of 3xx that largely ignores HTTP semantics
 				redirect, err := resp.Location()
 				if err != nil {
+					fmt.Println("error in location", err)
 					c.common.Logger.Errorf(ctx, "%d redirect, but no valid location: %s", resp.StatusCode, err)
 					return err, duration
 				}
@@ -148,6 +150,9 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (err error, retryAfter sh
 				// Set the URL to the redirect, so that it connects to it on the
 				// next cycle.
 				c.url = redirect
+
+				// don't delay in following the redirect
+				duration = sharedinternal.ZeroDuration
 			} else {
 				c.common.Logger.Errorf(ctx, "Server responded with status=%v", resp.Status)
 			}

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -137,7 +136,7 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (err error, retryAfter sh
 				// very liberal handling of 3xx that largely ignores HTTP semantics
 				redirect, err := resp.Location()
 				if err != nil {
-					fmt.Println("error in location", err)
+					c.common.Callbacks.OnConnectFailed(ctx, err)
 					c.common.Logger.Errorf(ctx, "%d redirect, but no valid location: %s", resp.StatusCode, err)
 					return err, duration
 				}
@@ -151,9 +150,6 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (err error, retryAfter sh
 				// Set the URL to the redirect, so that it connects to it on the
 				// next cycle.
 				c.url = redirect
-
-				// don't delay in following the redirect
-				duration = sharedinternal.ZeroDuration
 			} else {
 				c.common.Logger.Errorf(ctx, "Server responded with status=%v", resp.Status)
 			}

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -29,7 +29,7 @@ type wsClient struct {
 	requestHeader http.Header
 
 	// Websocket dialer and connection.
-	dialer    *websocket.Dialer
+	dialer    websocket.Dialer
 	conn      *websocket.Conn
 	connMutex sync.RWMutex
 
@@ -57,7 +57,7 @@ func (c *wsClient) Start(ctx context.Context, settings types.StartSettings) erro
 	}
 
 	// Prepare connection settings.
-	c.dialer = websocket.DefaultDialer
+	c.dialer = *websocket.DefaultDialer
 
 	var err error
 	c.url, err = url.Parse(settings.OpAMPServerURL)

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -136,7 +136,7 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (err error, retryAfter sh
 				// very liberal handling of 3xx that largely ignores HTTP semantics
 				redirect, err := resp.Location()
 				if err != nil {
-					c.common.Logger.Errorf(ctx, "3xx redirect, but no valid location: %s", err)
+					c.common.Logger.Errorf(ctx, "%d redirect, but no valid location: %s", resp.StatusCode, err)
 					return err, duration
 				}
 				if redirect.Scheme == "http" || redirect.Scheme == "" {

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -245,9 +245,11 @@ func TestRedirectWS(t *testing.T) {
 			startClient(t, settings, client)
 
 			// Wait for connection to be established.
-			eventually(t, func() bool { return conn.Load() != nil || connectErr.Load() != nil })
+			eventually(t, func() bool {
+				return conn.Load() != nil || connectErr.Load() != nil || client.lastInternalErr.Load() != nil
+			})
 			if test.ExpError {
-				if connectErr.Load() == nil {
+				if connectErr.Load() == nil && client.lastInternalErr.Load() == nil {
 					t.Error("expected non-nil error")
 				}
 			} else {

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -3,6 +3,9 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -176,4 +179,51 @@ func TestVerifyWSCompress(t *testing.T) {
 			}
 		})
 	}
+}
+
+func redirectServer(to string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, to, http.StatusSeeOther)
+	}))
+}
+
+func TestRedirectWS(t *testing.T) {
+	redirectee := internal.StartMockServer(t)
+	redirector := redirectServer("ws://" + redirectee.Endpoint)
+	defer redirector.Close()
+
+	var conn atomic.Value
+	redirectee.OnWSConnect = func(c *websocket.Conn) {
+		conn.Store(c)
+	}
+
+	// Start an OpAMP/WebSocket client.
+	var connected int64
+	var connectErr atomic.Value
+	settings := types.StartSettings{
+		Callbacks: types.CallbacksStruct{
+			OnConnectFunc: func(ctx context.Context) {
+				atomic.StoreInt64(&connected, 1)
+			},
+			OnConnectFailedFunc: func(ctx context.Context, err error) {
+				if err != websocket.ErrBadHandshake {
+					connectErr.Store(err)
+				}
+			},
+		},
+	}
+	reURL, err := url.Parse(redirector.URL)
+	assert.NoError(t, err)
+	reURL.Scheme = "ws"
+	settings.OpAMPServerURL = reURL.String()
+	client := NewWebSocket(nil)
+	startClient(t, settings, client)
+
+	// Wait for connection to be established.
+	eventually(t, func() bool { return conn.Load() != nil })
+	assert.True(t, connectErr.Load() == nil)
+
+	// Stop the client.
+	err = client.Stop(context.Background())
+	assert.NoError(t, err)
 }

--- a/internal/retryafter.go
+++ b/internal/retryafter.go
@@ -17,12 +17,6 @@ type OptionalDuration struct {
 	Defined bool
 }
 
-// ZeroDuration represents a zero length duration that is defined.
-var ZeroDuration = OptionalDuration{
-	Duration: 0,
-	Defined:  true,
-}
-
 func parseDelaySeconds(s string) (time.Duration, error) {
 	n, err := strconv.Atoi(s)
 

--- a/internal/retryafter.go
+++ b/internal/retryafter.go
@@ -17,6 +17,12 @@ type OptionalDuration struct {
 	Defined bool
 }
 
+// ZeroDuration represents a zero length duration that is defined.
+var ZeroDuration = OptionalDuration{
+	Duration: 0,
+	Defined:  true,
+}
+
 func parseDelaySeconds(s string) (time.Duration, error) {
 	n, err := strconv.Atoi(s)
 


### PR DESCRIPTION
This commit allows the opamp client to follow redirects after websocket handshake failures. Redirect following is not implemented by gorilla/websocket, but can be handled by inspecting the returned response object for 3xx status and Location header.

Closes #250 