### PR TITLE
Remove OnOpampConnectionSettingsAccepted callback

### DIFF
--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -210,9 +210,8 @@ func (r *receivedProcessor) rcvOpampConnectionSettings(ctx context.Context, sett
 
 	if r.hasCapability(protobufs.AgentCapabilities_AgentCapabilities_AcceptsOpAMPConnectionSettings) {
 		err := r.callbacks.OnOpampConnectionSettings(ctx, settings.Opamp)
-		if err == nil {
-			// TODO: verify connection using new settings.
-			r.callbacks.OnOpampConnectionSettingsAccepted(ctx, settings.Opamp)
+		if err != nil {
+			r.logger.Errorf(ctx, "Failed to process OpAMPConnectionSettings: %v", err)
 		}
 	} else {
 		r.logger.Debugf(ctx, "Ignoring Opamp, agent does not have AcceptsOpAMPConnectionSettings capability")


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opamp-go/issues/261

I intentionally left undefined the blocking vs nonblocking requirement for the callback. I suggest that we refine this after we make implementations and settle on a particular behavior.

A continuation of this PR is needed that implements steps 4 and 5 of the flow described here:
https://github.com/open-telemetry/opamp-go/issues/261