### PR TITLE
Add CheckRedirect callback

### DIFF
--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -258,7 +258,7 @@ func TestRedirectHTTP(t *testing.T) {
 		{
 			Name:         "check redirect returns error",
 			Redirector:   redirectServer("http://"+redirectee.Endpoint, 302),
-			MockRedirect: mockRedirect(t, 1, errors.New("hello")),
+			MockRedirect: mockRedirectHTTP(t, 1, errors.New("hello")),
 			ExpError:     true,
 		},
 	}

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -98,6 +98,14 @@ func (h *HTTPSender) Run(
 	h.callbacks = callbacks
 	h.receiveProcessor = newReceivedProcessor(h.logger, callbacks, h, clientSyncedState, packagesStateProvider, capabilities, packageSyncMutex)
 
+	// we need to detect if the redirect was ever set, if not, we want default behaviour
+	if callbacks.CheckRedirect != nil {
+		h.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			// viaResp only non-nil for ws client
+			return callbacks.CheckRedirect(req, via, nil)
+		}
+	}
+
 	for {
 		pollingTimer := time.NewTimer(time.Millisecond * time.Duration(atomic.LoadInt64(&h.pollingIntervalMs)))
 		select {

--- a/client/types/callbacks.go
+++ b/client/types/callbacks.go
@@ -112,10 +112,18 @@ type Callbacks struct {
 	// OnCommand is called when the Server requests that the connected Agent perform a command.
 	OnCommand func(ctx context.Context, command *protobufs.ServerToAgentCommand) error
 
-	// CheckRedirect is called before following a redirect. It is similar in
-	// nature to the CheckRedirect in net/http's Client. If the value is nil,
-	// then the http client's CheckRedirect will not be altered.
-	CheckRedirect func(req *http.Request, via []*http.Response) error
+	// CheckRedirect is called before following a redirect, allowing the client
+	// the opportunity to observe the redirect chain, and optionally terminate
+	// following redirects early.
+	//
+	// CheckRedirect is intended to be similar, although not exactly equivalent,
+	// to net/http.Client's CheckRedirect feature. Unlike in net/http, the via
+	// parameter is a slice of HTTP responses, instead of requests. This gives
+	// an opportunity to users to know what the exact response headers and
+	// status were. The request itself can be obtained from the response.
+	//
+	// The responses in the via parameter are passed with their bodies closed.
+	CheckRedirect func(req *http.Request, viaReq []*http.Request, via []*http.Response) error
 }
 
 func (c *Callbacks) SetDefaults() {

--- a/client/types/callbacks.go
+++ b/client/types/callbacks.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
@@ -110,6 +111,11 @@ type Callbacks struct {
 
 	// OnCommand is called when the Server requests that the connected Agent perform a command.
 	OnCommand func(ctx context.Context, command *protobufs.ServerToAgentCommand) error
+
+	// CheckRedirect is called before following a redirect. It is similar in
+	// nature to the CheckRedirect in net/http's Client. If the value is nil,
+	// then the http client's CheckRedirect will not be altered.
+	CheckRedirect func(req *http.Request, via []*http.Response) error
 }
 
 func (c *Callbacks) SetDefaults() {

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -48,6 +48,12 @@ type wsClient struct {
 	// Network connection timeout used for the WebSocket closing handshake.
 	// This field is currently only modified during testing.
 	connShutdownTimeout time.Duration
+
+	// responseChain is used for the "via" argument in CheckRedirect.
+	// It is appended to with every redirect followed, and zeroed on a succesful
+	// connection. responseChain should only be referred to by the goroutine that
+	// runs tryConnectOnce and its synchronous callees.
+	responseChain []*http.Response
 }
 
 // NewWebSocket creates a new OpAMP Client that uses WebSocket transport.
@@ -151,11 +157,69 @@ func (c *wsClient) SendCustomMessage(message *protobufs.CustomMessage) (messageS
 	return c.common.SendCustomMessage(message)
 }
 
+// handleRedirect checks a failed websocket upgrade response for a 3xx response
+// and a Location header. If found, it sets the URL to the location found in the
+// header so that it is tried on the next retry, instead of the current URL.
+func (c *wsClient) handleRedirect(ctx context.Context, resp *http.Response) error {
+	// append to the responseChain so that subsequent redirects will have access
+	c.responseChain = append(c.responseChain, resp)
+
+	// very liberal handling of 3xx that largely ignores HTTP semantics
+	redirect, err := resp.Location()
+	if err != nil {
+		c.common.Logger.Errorf(ctx, "%d redirect, but no valid location: %s", resp.StatusCode, err)
+		return err
+	}
+
+	// It's slightly tricky to make CheckRedirect work. The WS HTTP request is
+	// formed within the websocket library. To work around that, copy the
+	// previous request, available in the response, and set the URL to the new
+	// location. It should then result in the same URL that the websocket
+	// library will form.
+	nextRequest := resp.Request.Clone(ctx)
+	nextRequest.URL = redirect
+
+	// if CheckRedirect results in an error, it gets returned, terminating
+	// redirection. As with stdlib, the error is wrapped in url.Error.
+	if c.common.Callbacks.CheckRedirect != nil {
+		if err := c.common.Callbacks.CheckRedirect(nextRequest, c.responseChain); err != nil {
+			return &url.Error{
+				Op:  "Get",
+				URL: nextRequest.URL.String(),
+				Err: err,
+			}
+		}
+	}
+
+	// rewrite the scheme for the sake of tolerance
+	if redirect.Scheme == "http" {
+		redirect.Scheme = "ws"
+	} else if redirect.Scheme == "https" {
+		redirect.Scheme = "wss"
+	}
+	c.common.Logger.Debugf(ctx, "%d redirect to %s", resp.StatusCode, redirect)
+
+	// Set the URL to the redirect, so that it connects to it on the
+	// next cycle.
+	c.url = redirect
+
+	return nil
+}
+
 // Try to connect once. Returns an error if connection fails and optional retryAfter
 // duration to indicate to the caller to retry after the specified time as instructed
 // by the Server.
 func (c *wsClient) tryConnectOnce(ctx context.Context) (retryAfter sharedinternal.OptionalDuration, err error) {
 	var resp *http.Response
+	var redirecting bool
+	defer func() {
+		if err != nil && !redirecting {
+			c.responseChain = nil
+			if c.common.Callbacks != nil && !c.common.IsStopping() {
+				c.common.Callbacks.OnConnectFailed(ctx, err)
+			}
+		}
+	}()
 	conn, resp, err := c.dialer.DialContext(ctx, c.url.String(), c.getHeader())
 	if err != nil {
 		if !c.common.IsStopping() {
@@ -164,22 +228,10 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (retryAfter sharedinterna
 		if resp != nil {
 			duration := sharedinternal.ExtractRetryAfterHeader(resp)
 			if resp.StatusCode >= 300 && resp.StatusCode < 400 {
-				// very liberal handling of 3xx that largely ignores HTTP semantics
-				redirect, err := resp.Location()
-				if err != nil {
-					c.common.Logger.Errorf(ctx, "%d redirect, but no valid location: %s", resp.StatusCode, err)
+				redirecting = true
+				if err := c.handleRedirect(ctx, resp); err != nil {
 					return duration, err
 				}
-				// rewrite the scheme for the sake of tolerance
-				if redirect.Scheme == "http" {
-					redirect.Scheme = "ws"
-				} else if redirect.Scheme == "https" {
-					redirect.Scheme = "wss"
-				}
-				c.common.Logger.Debugf(ctx, "%d redirect to %s", resp.StatusCode, redirect)
-				// Set the URL to the redirect, so that it connects to it on the
-				// next cycle.
-				c.url = redirect
 			} else {
 				c.common.Logger.Errorf(ctx, "Server responded with status=%v", resp.Status)
 			}

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -333,6 +333,7 @@ type checkRedirectMock struct {
 func (c *checkRedirectMock) CheckRedirect(req *http.Request, via []*http.Response) error {
 	if req == nil {
 		c.t.Error("nil request in CheckRedirect")
+		return errors.New("nil request in CheckRedirect")
 	}
 	if len(via) > c.viaLen {
 		c.t.Error("via should be shorter than viaLen")

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/stretchr/testify v1.10.0
@@ -12,8 +13,8 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This commit adds a CheckRedirect callback that opamp-go will call before
following a redirect from the server it's trying to connect to. Like in
net/http, CheckRedirect can be used to observe the request chain that
the client is taking while attempting to make a connection.

The user can optionally terminate redirect following by returning an
error from CheckRedirect.

Unlike in net/http, the via parameter for CheckRedirect is a slice of
responses. Since the user would have no other way to access these in the
context of opamp-go, CheckRedirect makes them available so that users
can know exactly what status codes and headers are set in the response.

Another small improvement is that the error callback is no longer called
when redirecting. This should help to prevent undue error logging by
opamp-go consumers. Since the CheckRedirect callback is now available,
it also doesn't represent any loss in functionality to opamp-go
consumers.