### PR TITLE
move codeboten to emeritus approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Approvers ([@open-telemetry/opamp-go-approvers](https://github.com/orgs/open-telemetry/teams/opamp-go-approvers)):
 
-- [Alex Boten](https://github.com/codeboten), Lightstep
 - [Anthony Mirabella](https://github.com/Aneurysm9), AWS
 - [Evan Bradley](https://github.com/evan-bradley), Dynatrace
 - [Srikanth Chekuri](https://github.com/srikanthccv), signoz.io
 
 Emeritus Approvers
 
+- [Alex Boten](https://github.com/codeboten), Lightstep
 - [Przemek Maciolek](https://github.com/pmm-sumo), Sumo Logic
 
 Maintainers ([@open-telemetry/opamp-go-maintainers](https://github.com/orgs/open-telemetry/teams/opamp-go-maintainers)):


### PR DESCRIPTION
I've not had time or bandwidth to follow the work in this repo.