### PR TITLE
docs: fix broken link

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -18,7 +18,7 @@
 package tools
 
 // This file follows the recommendation at
-// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 // on how to pin tooling dependencies to a go.mod file.
 // This ensures that all systems use the same version of tools in addition to regular dependencies.
 


### PR DESCRIPTION
The Go wiki on GitHub has moved to go.dev. This PR updates a comment to link to its new place.