### PR TITLE
Amend Retry-After parsing logic for negative durations

### DIFF
--- a/internal/retryafter.go
+++ b/internal/retryafter.go
@@ -24,7 +24,7 @@ func parseDelaySeconds(s string) (time.Duration, error) {
 		return 0, errCouldNotParseRetryAfterHeader
 	}
 
-	// If n > 0 return n seconds, otherwise return 0.
+	// If n > 0 return n seconds, otherwise return 0
 	if n > 0 {
 		duration := time.Duration(n) * time.Second
 		return duration, nil
@@ -39,7 +39,7 @@ func parseHTTPDate(s string) (time.Duration, error) {
 		return 0, errCouldNotParseRetryAfterHeader
 	}
 
-	// If the date is in the future return that duration, otherwise return 0.
+	// If the date is in the future return that duration, otherwise return 0
 	if duration := time.Until(t); duration > 0 {
 		return duration, nil
 	}

--- a/internal/retryafter.go
+++ b/internal/retryafter.go
@@ -18,26 +18,32 @@ type OptionalDuration struct {
 }
 
 func parseDelaySeconds(s string) (time.Duration, error) {
+	// Verify duration parsed properly
 	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, errCouldNotParseRetryAfterHeader
+	}
 
-	// Verify duration parsed properly and bigger than 0
-	if err == nil && n > 0 {
+	// If n > 0 return n seconds, otherwise return 0.
+	if n > 0 {
 		duration := time.Duration(n) * time.Second
 		return duration, nil
 	}
-	return 0, errCouldNotParseRetryAfterHeader
+	return 0, nil
 }
 
 func parseHTTPDate(s string) (time.Duration, error) {
+	// Verify duration parsed properly
 	t, err := http.ParseTime(s)
-
-	// Verify duration parsed properly and bigger than 0
-	if err == nil {
-		if duration := time.Until(t); duration > 0 {
-			return duration, nil
-		}
+	if err != nil {
+		return 0, errCouldNotParseRetryAfterHeader
 	}
-	return 0, errCouldNotParseRetryAfterHeader
+
+	// If the date is in the future return that duration, otherwise return 0.
+	if duration := time.Until(t); duration > 0 {
+		return duration, nil
+	}
+	return 0, nil
 }
 
 // ExtractRetryAfterHeader extracts Retry-After response header if the status

--- a/internal/retryafter_test.go
+++ b/internal/retryafter_test.go
@@ -56,9 +56,9 @@ func TestExtractRetryAfterHeaderDelaySeconds(t *testing.T) {
 }
 
 func TestExtractRetryAfterHeaderHttpDate(t *testing.T) {
-	// Generate a random n > 0 second duration
+	// Generate a random n >= 1 second duration
 	now := time.Now()
-	retryIntervalSec := rand.Intn(9999)
+	retryIntervalSec := 1 + rand.Intn(9999)
 	expectedDuration := time.Second * time.Duration(retryIntervalSec)
 
 	// Set a response with Retry-After header = random n > 0 int


### PR DESCRIPTION
The initial implementation of this PR attempted to fix the TestExtractRetryAfterHeaderHttpDate test by making sure the test duration was in the future. After the comment by Tigran I've pivoted to fix the parsing logic instead.

This PR amends the `parseHTTPDate` and `parseDelaySeconds` helpers to not return an error if the parsed duration is in the past; instead they now return a zero duration and nil error to trigger immediate polling.

In the current logic and the two places ([1](https://github.com/open-telemetry/opamp-go/blob/0fd73cc08a56ae911c196b6cb17bdd917e919009/client/internal/httpsender.go#L185), [2](https://github.com/open-telemetry/opamp-go/blob/0fd73cc08a56ae911c196b6cb17bdd917e919009/client/wsclient.go#L201)) it's being used, it looks that in the case that a negative seconds or a date in the past was set in the header, both the HTTP and WebSocket clients would reuse the last valid calculated interval, while now it would correctly poll right away.


### Old PR description
This PR fixes a timing issue with TestExtractRetryAfterHeaderHttpDate that makes it flaky.

To see the failure, run the following command a couple of times

```
$ go test -run TestExtractRetryAfterHeaderHttpDate -count=20000 -shuffle=on ./...
```

The failure itself has to do with the following snippet; technically we're only adding `>=0` seconds of delay. If you're lucky enough to add `0s` as the duration, then the time.Until condition hits and the header cannot be parsed properly

https://github.com/open-telemetry/opamp-go/blob/1a9603e3d2ded1c7a63917e6d13c4d6e22a7af6d/internal/retryafter_test.go#L61-L62

https://github.com/open-telemetry/opamp-go/blob/ba3b5ff1db417943eed2b004aad6301494a0a4ea/internal/retryafter.go#L35-L40


Fixes #181 