### PR TITLE
Fix race condition around supervisor's Commander

### DIFF
--- a/internal/examples/supervisor/supervisor/commander/commander.go
+++ b/internal/examples/supervisor/supervisor/commander/commander.go
@@ -125,15 +125,14 @@ func (c *Commander) IsRunning() bool {
 // and if the process does not finish kills it forcedly by sending SIGKILL.
 // Returns after the process is terminated.
 func (c *Commander) Stop(ctx context.Context) error {
-	if !c.IsRunning() {
-		// Not started, nothing to do.
-		return nil
-	}
-
 	c.isStoppingMutex.Lock()
 	c.isStoppingFlag = true
 	c.isStoppingMutex.Unlock()
 
+	if !c.IsRunning() {
+		// Not started, nothing to do.
+		return nil
+	}
 	c.logger.Debugf(ctx, "Stopping agent process, PID=%v", c.cmd.Process.Pid)
 
 	// Gracefully signal process to stop.

--- a/internal/examples/supervisor/supervisor/commander/commander.go
+++ b/internal/examples/supervisor/supervisor/commander/commander.go
@@ -94,7 +94,7 @@ func (c *Commander) Done() <-chan struct{} {
 
 // Pid returns Agent process PID if it is started or 0 if it is not.
 func (c *Commander) Pid() int {
-	if c.cmd == nil || c.cmd.Process == nil {
+	if !c.IsRunning() {
 		return 0
 	}
 	return c.cmd.Process.Pid

--- a/internal/noplogger.go
+++ b/internal/noplogger.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"time"
 
 	"github.com/open-telemetry/opamp-go/client/types"
 )
@@ -12,3 +13,12 @@ type NopLogger struct{}
 
 func (l *NopLogger) Debugf(ctx context.Context, format string, v ...interface{}) {}
 func (l *NopLogger) Errorf(ctx context.Context, format string, v ...interface{}) {}
+
+type DelayLogger struct{}
+
+func (l *DelayLogger) Debugf(ctx context.Context, format string, v ...interface{}) {
+	time.Sleep(10 * time.Millisecond)
+}
+func (l *DelayLogger) Errorf(ctx context.Context, format string, v ...interface{}) {
+	time.Sleep(10 * time.Millisecond)
+}


### PR DESCRIPTION
From what I'd see under normal circumstances (and also the example), starting up the supervisor which also launches the commander would happen in a separate goroutine than the one that inspects its state or calls Stop.

The current implementation has a race condition on the `cmd *exec.Cmd` field, using it both for figuring out whether the commander is running and also actually executing a new Agent process, which could potentially lead to a panic.

This PR fixes a small race condition around the supervisor's Commander by utilizing an existing `running` field and turning it into a `atomic.Bool` to store the commander's state.

Fixes #290 