### PR TITLE
Fix flaky TestSendCustomMessagePendingError

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -1905,8 +1905,6 @@ func TestSendCustomMessagePendingError(t *testing.T) {
 		}
 		client.SetCustomCapabilities(clientCustomCapabilities)
 
-		assert.NoError(t, client.Start(context.Background(), settings))
-
 		customMessage1 := &protobufs.CustomMessage{
 			Capability: "local.test.example",
 			Type:       "hello",
@@ -1918,6 +1916,7 @@ func TestSendCustomMessagePendingError(t *testing.T) {
 			Data:       []byte("test message 2"),
 		}
 
+		// Send a message to the unstarted client.
 		_, err := client.SendCustomMessage(customMessage1)
 		assert.NoError(t, err)
 
@@ -1925,6 +1924,9 @@ func TestSendCustomMessagePendingError(t *testing.T) {
 		sendingChan, err := client.SendCustomMessage(customMessage2)
 		assert.ErrorIs(t, err, types.ErrCustomMessagePending)
 		assert.NotNil(t, sendingChan)
+
+		// Start the client so we can start processing messages properly.
+		assert.NoError(t, client.Start(context.Background(), settings))
 
 		// Receive the first custom message
 		eventually(


### PR DESCRIPTION
I'm not _entirely_ sure this is the correct way to test this, so any feedback is appreciated cc @andykellr 

The flake is easy to reproduce currently with `go test -run=TestSendCustomMessagePendingError -count=1000 -race` .

After this fix, I've given it >25k runs and didn't manage to get any failures at all.

#### Background
The flakiness in `TestSendCustomMessagePendingError` was due to the fact that the second call to `SendCustomMessage` was often not fast enough to trigger the condition, giving the first call to c.sender.ScheduleSend() enough time for a message to be sent and clearing the previous CustomMessage from the sender's first queued message in the process.

#### Solution
Without going deeper to add explicit synchronization, I think that delaying the start to the server can guarantee that no messages are sent out at the beginning, and starting it up later is stil valid for the rest of the assertions

Fixes #278 

