### PR TITLE
Add HeaderFunc to allow modifying headers before every request

### DIFF
--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -44,7 +44,7 @@ func (c *httpClient) Start(ctx context.Context, settings types.StartSettings) er
 	c.opAMPServerURL = settings.OpAMPServerURL
 
 	// Prepare Server connection settings.
-	c.sender.SetRequestHeader(settings.Header)
+	c.sender.SetRequestHeader(settings.Header, settings.HeaderFunc)
 
 	// Add TLS configuration into httpClient
 	c.sender.AddTLSConfig(settings.TLSConfig)

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -17,6 +17,10 @@ type StartSettings struct {
 	// Optional additional HTTP headers to send with all HTTP requests.
 	Header http.Header
 
+	// Optional function that can be used to modify the HTTP headers
+	// before each HTTP request.
+	HeaderFunc func(http.Header) http.Header
+
 	// Optional TLS config for HTTP connection.
 	TLSConfig *tls.Config
 

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -19,6 +19,7 @@ type StartSettings struct {
 
 	// Optional function that can be used to modify the HTTP headers
 	// before each HTTP request.
+	// Can modify and return the argument or return the argument without modifying.
 	HeaderFunc func(http.Header) http.Header
 
 	// Optional TLS config for HTTP connection.

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -31,7 +31,7 @@ type wsClient struct {
 	url *url.URL
 
 	// HTTP request headers to use when connecting to OpAMP Server.
-	requestHeader http.Header
+	getHeader func() http.Header
 
 	// Websocket dialer and connection.
 	dialer    websocket.Dialer
@@ -86,7 +86,21 @@ func (c *wsClient) Start(ctx context.Context, settings types.StartSettings) erro
 	}
 	c.dialer.TLSClientConfig = settings.TLSConfig
 
-	c.requestHeader = settings.Header
+	headerFunc := settings.HeaderFunc
+	if headerFunc == nil {
+		headerFunc = func(h http.Header) http.Header {
+			return h
+		}
+	}
+
+	baseHeader := settings.Header
+	if baseHeader == nil {
+		baseHeader = http.Header{}
+	}
+
+	c.getHeader = func() http.Header {
+		return headerFunc(baseHeader.Clone())
+	}
 
 	c.common.StartConnectAndRun(c.runUntilStopped)
 
@@ -142,7 +156,7 @@ func (c *wsClient) SendCustomMessage(message *protobufs.CustomMessage) (messageS
 // by the Server.
 func (c *wsClient) tryConnectOnce(ctx context.Context) (retryAfter sharedinternal.OptionalDuration, err error) {
 	var resp *http.Response
-	conn, resp, err := c.dialer.DialContext(ctx, c.url.String(), c.requestHeader)
+	conn, resp, err := c.dialer.DialContext(ctx, c.url.String(), c.getHeader())
 	if err != nil {
 		if c.common.Callbacks != nil && !c.common.IsStopping() {
 			c.common.Callbacks.OnConnectFailed(ctx, err)


### PR DESCRIPTION
Adds a new HeaderFunc to the StartSettings that allows for dynamically editing the headers before each HTTP request made by the OpAMP library.

Closes #297