### PR TITLE
Pass opts to otlpmetrichttp.New()

### DIFF
--- a/internal/examples/agent/agent/metricreporter.go
+++ b/internal/examples/agent/agent/metricreporter.go
@@ -72,7 +72,7 @@ func NewMetricReporter(
 		opts = append(opts, otlpmetrichttp.WithInsecure())
 	}
 
-	metricExporter, err := otlpmetrichttp.New(context.Background())
+	metricExporter, err := otlpmetrichttp.New(context.Background(), opts...)
 	if err != nil {
 		err := fmt.Errorf("failed to initialize stdoutmetric export pipeline: %v", err)
 		return nil, err


### PR DESCRIPTION
opts is created but never used.  It's necessary to pass opts the otlpmetrichttp.New() so that the configured destinationEnpoint is correctly used.