### PR TITLE
Allow setting initial heartbeat interval

### DIFF
--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -172,10 +172,10 @@ func TestHTTPClientStartWithHeartbeatInterval(t *testing.T) {
 			}
 
 			// Start a client.
-			heartbeatSec := 1
+			heartbeat := 10 * time.Millisecond
 			settings := types.StartSettings{
-				OpAMPServerURL:          "http://" + srv.Endpoint,
-				HeartbeatIntervalSecond: &heartbeatSec,
+				OpAMPServerURL:    "http://" + srv.Endpoint,
+				HeartbeatInterval: &heartbeat,
 			}
 			if tt.enableHeartbeat {
 				settings.Capabilities = protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat
@@ -189,10 +189,10 @@ func TestHTTPClientStartWithHeartbeatInterval(t *testing.T) {
 			eventually(t, func() bool { return atomic.LoadInt64(&rcvCounter) == 1 })
 
 			if tt.expectHeartbeats {
-				// Verify that status report is delivered again. no call is made for next 100ms
-				assert.Eventually(t, func() bool { return atomic.LoadInt64(&rcvCounter) == 2 }, 5*time.Second, 100*time.Millisecond)
+				// Verify that status report is delivered again. no call is made for next 10ms
+				assert.Eventually(t, func() bool { return atomic.LoadInt64(&rcvCounter) >= 2 }, 50*time.Second, 10*time.Millisecond)
 			} else {
-				assert.Never(t, func() bool { return atomic.LoadInt64(&rcvCounter) == 2 }, 5*time.Second, 100*time.Millisecond)
+				assert.Never(t, func() bool { return atomic.LoadInt64(&rcvCounter) >= 2 }, 50*time.Millisecond, 10*time.Millisecond)
 			}
 
 			// Shutdown the Server.
@@ -209,11 +209,11 @@ func TestHTTPClientStartWithZeroHeartbeatInterval(t *testing.T) {
 	srv := internal.StartMockServer(t)
 
 	// Start a client.
-	heartbeat := 0
+	heartbeat := 0 * time.Millisecond
 	settings := types.StartSettings{
-		OpAMPServerURL:          "http://" + srv.Endpoint,
-		HeartbeatIntervalSecond: &heartbeat,
-		Capabilities:            protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat,
+		OpAMPServerURL:    "http://" + srv.Endpoint,
+		HeartbeatInterval: &heartbeat,
+		Capabilities:      protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat,
 	}
 	client := NewHTTP(nil)
 	prepareClient(t, &settings, client)

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -189,8 +189,7 @@ func TestHTTPClientStartWithHeartbeatInterval(t *testing.T) {
 			eventually(t, func() bool { return atomic.LoadInt64(&rcvCounter) == 1 })
 
 			if tt.expectHeartbeats {
-				// Verify that status report is delivered again. no call is made for next 10ms
-				assert.Eventually(t, func() bool { return atomic.LoadInt64(&rcvCounter) >= 2 }, 50*time.Second, 10*time.Millisecond)
+				assert.Eventually(t, func() bool { return atomic.LoadInt64(&rcvCounter) >= 2 }, 5*time.Second, 10*time.Millisecond)
 			} else {
 				assert.Never(t, func() bool { return atomic.LoadInt64(&rcvCounter) >= 2 }, 50*time.Millisecond, 10*time.Millisecond)
 			}

--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -138,8 +137,8 @@ func (c *ClientCommon) PrepareStart(
 		c.Callbacks = types.CallbacksStruct{}
 	}
 
-	if c.Capabilities&protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat != 0 && settings.HeartbeatIntervalSecond != nil {
-		if err := c.sender.SetHeartbeatInterval(time.Duration(*settings.HeartbeatIntervalSecond) * time.Second); err != nil {
+	if c.Capabilities&protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat != 0 && settings.HeartbeatInterval != nil {
+		if err := c.sender.SetHeartbeatInterval(*settings.HeartbeatInterval); err != nil {
 			return err
 		}
 	}

--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -135,6 +136,12 @@ func (c *ClientCommon) PrepareStart(
 	if c.Callbacks == nil {
 		// Make sure it is always safe to call Callbacks.
 		c.Callbacks = types.CallbacksStruct{}
+	}
+
+	if c.Capabilities&protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat != 0 && settings.HeartbeatIntervalSecond != nil {
+		if err := c.sender.SetHeartbeatInterval(time.Duration(*settings.HeartbeatIntervalSecond) * time.Second); err != nil {
+			return err
+		}
 	}
 
 	if err := c.sender.SetInstanceUid(settings.InstanceUid); err != nil {

--- a/client/internal/wssender_test.go
+++ b/client/internal/wssender_test.go
@@ -12,17 +12,17 @@ func TestWSSenderSetHeartbeatInterval(t *testing.T) {
 	sender := NewSender(&sharedinternal.NopLogger{})
 
 	// Default interval should be 30s as per OpAMP Specification
-	assert.Equal(t, int64((30 * time.Second).Seconds()), sender.heartbeatIntervalSeconds.Load())
+	assert.Equal(t, int64((30 * time.Second).Milliseconds()), sender.heartbeatIntervalMs.Load())
 
 	// negative interval is invalid for http sender
 	assert.Error(t, sender.SetHeartbeatInterval(-1))
-	assert.Equal(t, int64((30 * time.Second).Seconds()), sender.heartbeatIntervalSeconds.Load())
+	assert.Equal(t, int64((30 * time.Second).Milliseconds()), sender.heartbeatIntervalMs.Load())
 
 	// zero is valid for ws sender
 	assert.NoError(t, sender.SetHeartbeatInterval(0))
-	assert.Equal(t, int64(0), sender.heartbeatIntervalSeconds.Load())
+	assert.Equal(t, int64(0), sender.heartbeatIntervalMs.Load())
 
-	var expected int64 = 10
-	assert.NoError(t, sender.SetHeartbeatInterval(time.Duration(expected)*time.Second))
-	assert.Equal(t, expected, sender.heartbeatIntervalSeconds.Load())
+	var expected int64 = 10000
+	assert.NoError(t, sender.SetHeartbeatInterval(time.Duration(expected)*time.Millisecond))
+	assert.Equal(t, expected, sender.heartbeatIntervalMs.Load())
 }

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -53,4 +53,14 @@ type StartSettings struct {
 	// the compression is only effectively enabled if the Server also supports compression.
 	// The data will be compressed in both directions.
 	EnableCompression bool
+
+	// Optional HeartbeatIntervalSecond to configure the heartbeat interval for client.
+	// If nil, the default heartbeat interval (30s) will be used.
+	// If zero, heartbeat will be disabled for a Websocket-based client.
+	//
+	// Note that an HTTP-based client will use the heartbeat interval as its polling interval
+	// and zero is invalid for an HTTP-based client.
+	//
+	// If the ReportsHeartbeat capability is disabled, this option has no effect.
+	HeartbeatIntervalSecond *int
 }

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -3,6 +3,7 @@ package types
 import (
 	"crypto/tls"
 	"net/http"
+	"time"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
@@ -54,7 +55,7 @@ type StartSettings struct {
 	// The data will be compressed in both directions.
 	EnableCompression bool
 
-	// Optional HeartbeatIntervalSecond to configure the heartbeat interval for client.
+	// Optional HeartbeatInterval to configure the heartbeat interval for client.
 	// If nil, the default heartbeat interval (30s) will be used.
 	// If zero, heartbeat will be disabled for a Websocket-based client.
 	//
@@ -62,5 +63,5 @@ type StartSettings struct {
 	// and zero is invalid for an HTTP-based client.
 	//
 	// If the ReportsHeartbeat capability is disabled, this option has no effect.
-	HeartbeatIntervalSecond *int
+	HeartbeatInterval *time.Duration
 }

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -118,10 +118,10 @@ func TestWSClientStartWithHeartbeatInterval(t *testing.T) {
 			}
 
 			// Start an OpAMP/WebSocket client.
-			heartbeatSec := 1
+			heartbeat := 10 * time.Millisecond
 			settings := types.StartSettings{
-				OpAMPServerURL:          "ws://" + srv.Endpoint,
-				HeartbeatIntervalSecond: &heartbeatSec,
+				OpAMPServerURL:    "ws://" + srv.Endpoint,
+				HeartbeatInterval: &heartbeat,
 			}
 			if tt.clientEnableHeartbeat {
 				settings.Capabilities = protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat
@@ -135,11 +135,11 @@ func TestWSClientStartWithHeartbeatInterval(t *testing.T) {
 			if tt.expectHeartbeats {
 				assert.Eventually(t, func() bool {
 					return msgCount.Load() >= 2
-				}, 3*time.Second, 100*time.Millisecond)
+				}, 50*time.Millisecond, 10*time.Millisecond)
 			} else {
 				assert.Never(t, func() bool {
 					return msgCount.Load() >= 2
-				}, 3*time.Second, 100*time.Millisecond)
+				}, 50*time.Millisecond, 10*time.Millisecond)
 			}
 
 			// Stop the client.

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -135,7 +135,7 @@ func TestWSClientStartWithHeartbeatInterval(t *testing.T) {
 			if tt.expectHeartbeats {
 				assert.Eventually(t, func() bool {
 					return msgCount.Load() >= 2
-				}, 50*time.Millisecond, 10*time.Millisecond)
+				}, 5*time.Second, 10*time.Millisecond)
 			} else {
 				assert.Never(t, func() bool {
 					return msgCount.Load() >= 2


### PR DESCRIPTION
Add a `HeartbeatIntervalSecond` option to `StartSettings` to allow setting initial heartbeat interval.

resolve #303