### PR TITLE
Add workflow to run go mod tidy on renovatebot PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   setup-environment:

--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -2,6 +2,7 @@ name: static-check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     tags:
       - 'v*'

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,0 +1,47 @@
+name: go-mod-tidy
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+jobs:
+  setup-environment:
+    runs-on: ubuntu-latest
+    if: ${{ (github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'renovatebot')) }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Setup Go
+        uses: actions/setup-go@v5.1.0
+        with:
+          go-version: "1.22"
+      - name: Setup Go Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Cache Go
+        id: module-cache
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/go/pkg/mod
+          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+      - name: Install dependencies
+        if: steps.module-cache.outputs.cache-hit != 'true'
+        run: make gomoddownload
+      - name: Install Tools
+        if: steps.module-cache.outputs.cache-hit != 'true'
+        run: make install-tools
+      - name: go mod tidy, make all
+        run: |
+          make tidy && make all
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
+          echo "git diff --exit-code || (git add . && git commit -m \"go mod tidy, make all\" && git push)"
+          git diff --exit-code || (git add . && git commit -m "go mod tidy, make all" && git push)
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: renovatebot

--- a/makefile
+++ b/makefile
@@ -69,3 +69,10 @@ gomoddownload:
 .PHONY: install-tools
 install-tools:
 	cd $(TOOLS_MOD_DIR) && go install github.com/ory/go-acc
+
+.PHONY: tidy
+tidy:
+	rm -fr go.sum
+	go mod tidy
+	cd internal/examples && rm -fr go.sum && go mod tidy
+	cd internal/tools && rm -fr go.sum && go mod tidy


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opamp-go/issues/276

Verified here: https://github.com/srikanthccv/opamp-go/pull/11. You can notice that the build-and-test passes https://github.com/srikanthccv/opamp-go/actions/runs/11635165811/job/32403942593?pr=11

GitHub workflow won't be triggered from workflow https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow. Updated the types on pull_request to accept the `labeled`. We can re-trigger the workflow using label.