### PR TITLE
Do not run staticcheck on generated protobufs

### DIFF
--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   staticcheck:
     name: staticcheck (project)
+    strategy:
+      matrix:
+        dir: ["client", "internal", "server", "protobufshelpers"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,3 +28,4 @@ jobs:
         with:
           install-go: false
           version: "2023.1.7"
+          working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
Fixes #314 

The current staticcheck GitHub action doesn't support directory exclusions. I've implemented a matrix directory approach to fix issue #314. However, I suggest we move away from the staticcheck action entirely and create a new golang-lint CI action (taking inspiration from collector repo ci setup) instead. If that sounds good, I will create a separate PR(s) for the proposed change. Let me know what you think.