### PR TITLE
fix: `OnConnected` is called with a copied context.

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"context"
+	"time"
+)
+
+// Detach returns a context that keeps all the values of its parent context
+// but detaches from the cancellation and error handling.
+func Detach(ctx context.Context) context.Context { return detachedContext{ctx} }
+
+type detachedContext struct{ parent context.Context }
+
+func (v detachedContext) Deadline() (time.Time, bool)       { return time.Time{}, false }
+func (v detachedContext) Done() <-chan struct{}             { return nil }
+func (v detachedContext) Err() error                        { return nil }
+func (v detachedContext) Value(key interface{}) interface{} { return v.parent.Value(key) }

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -201,7 +201,7 @@ func (s *server) httpHandler(w http.ResponseWriter, req *http.Request) {
 
 	// Return from this func to reduce memory usage.
 	// Handle the connection on a separate goroutine.
-	go s.handleWSConnection(req.Context(), conn, connectionCallbacks)
+	go s.handleWSConnection(Detach(req.Context()), conn, connectionCallbacks)
 }
 
 func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Conn, connectionCallbacks serverTypes.ConnectionCallbacks) {


### PR DESCRIPTION
see #335.