### PR TITLE
Add client metrics for http and ws transports

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -141,6 +141,7 @@ func startClient(t *testing.T, settings types.StartSettings, client OpAMPClient)
 func createNoServerSettings() types.StartSettings {
 	return types.StartSettings{
 		OpAMPServerURL: "ws://" + testhelpers.GetAvailableLocalAddress(),
+		Metrics:        types.NewClientMetrics(64),
 	}
 }
 

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -37,6 +37,8 @@ func NewHTTP(logger types.Logger) *httpClient {
 
 // Start implements OpAMPClient.Start.
 func (c *httpClient) Start(ctx context.Context, settings types.StartSettings) error {
+	c.sender.SetMetrics(settings.Metrics)
+
 	if err := c.common.PrepareStart(ctx, settings); err != nil {
 		return err
 	}

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -180,6 +180,7 @@ func TestHTTPClientStartWithHeartbeatInterval(t *testing.T) {
 			settings := types.StartSettings{
 				OpAMPServerURL:    "http://" + srv.Endpoint,
 				HeartbeatInterval: &heartbeat,
+				Metrics:           types.NewClientMetrics(64),
 			}
 			if tt.enableHeartbeat {
 				settings.Capabilities = protobufs.AgentCapabilities_AgentCapabilities_ReportsHeartbeat

--- a/client/internal/metrics.go
+++ b/client/internal/metrics.go
@@ -1,0 +1,9 @@
+package internal
+
+type Counter interface {
+	Add(int64)
+}
+
+type RingBuffer[T any] interface {
+	Insert(T)
+}

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -10,6 +10,10 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
+type rcvProcessor interface {
+	ProcessReceivedMessage(context.Context, *protobufs.ServerToAgent)
+}
+
 // receivedProcessor handles the processing of messages received from the Server.
 type receivedProcessor struct {
 	logger types.Logger
@@ -41,8 +45,8 @@ func newReceivedProcessor(
 	packagesStateProvider types.PackagesStateProvider,
 	capabilities protobufs.AgentCapabilities,
 	packageSyncMutex *sync.Mutex,
-) receivedProcessor {
-	return receivedProcessor{
+) *receivedProcessor {
+	return &receivedProcessor{
 		logger:                logger,
 		callbacks:             callbacks,
 		sender:                sender,

--- a/client/internal/wssender_test.go
+++ b/client/internal/wssender_test.go
@@ -1,10 +1,14 @@
 package internal
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/open-telemetry/opamp-go/client/types"
 	sharedinternal "github.com/open-telemetry/opamp-go/internal"
+	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,4 +29,54 @@ func TestWSSenderSetHeartbeatInterval(t *testing.T) {
 	var expected int64 = 10000
 	assert.NoError(t, sender.SetHeartbeatInterval(time.Duration(expected)*time.Millisecond))
 	assert.Equal(t, expected, sender.heartbeatIntervalMs.Load())
+}
+
+func TestWSSendMessageMetrics(t *testing.T) {
+	msg := &protobufs.AgentToServer{
+		InstanceUid:  []byte("abcd"),
+		Capabilities: 2,
+		SequenceNum:  1,
+	}
+
+	sender := NewSender(TestLogger{T: t})
+	metrics := types.NewClientMetrics(64)
+	sender.SetMetrics(metrics)
+	wsConn := newFakeWSConn()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := sender.Start(ctx, wsConn); err != nil {
+		t.Fatal(err)
+	}
+	// this would be better to do within the interface of the sender, but by
+	// calling this method we bypass its internal queue which simplifies things
+	// somewhat
+	if err := sender.sendMessage(ctx, msg); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := metrics.TxMessages.Read(), int64(1); got != want {
+		t.Errorf("bad TxMessages count: got %d, want %d", got, want)
+	}
+	if metrics.TxBytes.Read() == 0 {
+		t.Error("TxBytes not counted")
+	}
+	if metrics.TxErrors.Read() != 0 {
+		t.Errorf("TxErrors counted when there were none")
+	}
+	messageInfo := metrics.TxMessageInfo.Drain()
+	if len(messageInfo) != 1 {
+		t.Fatal("wrong messageInfo len")
+	}
+	mi := messageInfo[0]
+	if got, want := mi.InstanceUID, []byte("abcd"); !cmp.Equal(got, want) {
+		t.Errorf("bad InstanceUID: got %v, want %v", got, want)
+	}
+	if got, want := mi.Capabilities, uint64(2); got != want {
+		t.Errorf("bad Capabilities: got %d, want %d", got, want)
+	}
+	if got, want := mi.SequenceNum, uint64(1); got != want {
+		t.Errorf("bad SequenceNum: got %d, want %d", got, want)
+	}
+	if mi.TxLatency == 0 {
+		t.Error("latency not tracked")
+	}
 }

--- a/client/types/metrics.go
+++ b/client/types/metrics.go
@@ -1,0 +1,161 @@
+package types
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// NewClientMetrics creates new ClientMetrics with a given buffer size for
+// collecting TxMessageInfo and RxMessageInfo. The buffer should be at least
+// size 1.
+func NewClientMetrics(bufSize int) *ClientMetrics {
+	return &ClientMetrics{
+		TxMessageInfo: NewRingBuffer[TxMessageInfo](bufSize),
+		RxMessageInfo: NewRingBuffer[RxMessageInfo](bufSize),
+	}
+}
+
+// ClientMetrics contains metrics about an OpAMP client and its interactions
+// with an OpAMP server.
+type ClientMetrics struct {
+	// RxBytes is the total number of bytes received by the client.
+	RxBytes Counter
+
+	// RxMessages is the total number of proto messages received by the client.
+	RxMessages Counter
+
+	// RxErrors is the total number of errors encountered while receiving
+	// messages. Typically, this would be due to interrupted connections or
+	// the client receiving a message that could not be decoded.
+	RxErrors Counter
+
+	// RxMessageInfo contains details about the last several messages to arrive.
+	RxMessageInfo *RingBuffer[RxMessageInfo]
+
+	// TxBytes is the total number of bytes sent during the session.
+	TxBytes Counter
+
+	// TxMessages is the total number of proto messages sent during the session.
+	TxMessages Counter
+
+	// TxErrors is the total number of errors encountered while sending
+	// messages to the server. Typically, this would be due to network errors.
+	TxErrors Counter
+
+	// TxMessageInfo contains details about the last several messages that
+	// were sent.
+	TxMessageInfo *RingBuffer[TxMessageInfo]
+}
+
+// Counter is an atomic counter with labels. The labels should not be modified
+// after creation.
+type Counter struct {
+	count  int64
+	Labels []string
+}
+
+// Add adds the amount to the counter. Negative amounts are OK.
+// Add is goroutine-safe.
+func (c *Counter) Add(amount int64) {
+	atomic.AddInt64(&c.count, amount)
+}
+
+// Read reads the current value of the counter. Read is goroutine-safe.
+func (c *Counter) Read() int64 {
+	return atomic.LoadInt64(&c.count)
+}
+
+// TxMessageInfo contains message metadata as well as the transmission latency.
+type TxMessageInfo struct {
+	// InstanceUID is the UUID of the agent or server. It should be 16 bytes long.
+	InstanceUID []byte
+
+	// SequenceNum is the sequence number of the message.
+	SequenceNum uint64
+
+	// Capabilities is ServerCapabilities or AgentCapabilities depending on the origin.
+	Capabilities uint64
+
+	// Attrs contain message metadata as bitfields.
+	Attrs MessageAttrs
+
+	// TxLatency is the time it took for the message to be sent.
+	TxLatency time.Duration
+}
+
+// RxMessageInfo contains message metadata.
+type RxMessageInfo struct {
+	// InstanceUID is the UUID of the agent or server. It should be 16 bytes long.
+	InstanceUID []byte
+
+	// SequenceNum is the sequence number of the message.
+	SequenceNum uint64
+
+	// Capabilities is ServerCapabilities or AgentCapabilities depending on the origin.
+	Capabilities uint64
+
+	// Attrs contain message metadata as bitfields.
+	Attrs MessageAttrs
+
+	// RxLatency is the time it took for the message to be received. RxLatency
+	// is not tracked for the websocket transport, since the protocol is
+	// asynchronous.
+	RxLatency time.Duration
+}
+
+// MessageAttrs are bitsets of MessageAttrs.
+type MessageAttrs uint64
+
+// MessageAttr is an individual message attribute.
+type MessageAttr uint64
+
+const (
+	// TxMessageAttr is set when the message was transmitted to us.
+	TxMessageAttr MessageAttr = 1
+
+	// RxMessageAttr is set when the message was sent by us.
+	RxMessageAttr MessageAttr = 1 << 1
+
+	// AgentToServerMessageAttr is sent when the message is an AgentToServer message.
+	AgentToServerMessageAttr MessageAttr = 1 << 2
+
+	// ServerToAgentMessageAttr is sent when the message is a ServerToAgent message.
+	ServerToAgentMessageAttr MessageAttr = 1 << 3
+
+	// ErrorMessageAttr is set when the message is an error response.
+	ErrorMessageAttr MessageAttr = 1 << 4
+
+	// HTTPTransportAttr is set when the message was sent on an HTTP transport.
+	HTTPTransportAttr MessageAttr = 1 << 5
+
+	// WSTransportAttr is set when the message was sent on a WS transport.
+	WSTransportAttr MessageAttr = 1 << 6
+)
+
+// Set adds attr to the bitset.
+func (m *MessageAttrs) Set(attr MessageAttr) {
+	*m = *m | MessageAttrs(attr)
+}
+
+// Unset removes attr from the bitset.
+func (m *MessageAttrs) Unset(attr MessageAttr) {
+	*m = *m & MessageAttrs(^attr)
+}
+
+// Slice returns all of the individual attributes as a slice.
+func (m *MessageAttrs) Slice() []MessageAttr {
+	result := []MessageAttr{}
+	selector := MessageAttr(1)
+	for i := 0; i < 64; i++ {
+		if m.Contains(selector) {
+			result = append(result, selector)
+		}
+		selector = selector << 1
+	}
+	return result
+}
+
+// Contains checks to see if the attr is contained in the bitset.
+func (m *MessageAttrs) Contains(attr MessageAttr) bool {
+	return (*m & MessageAttrs(attr)) > 0
+}

--- a/client/types/metrics_test.go
+++ b/client/types/metrics_test.go
@@ -1,0 +1,67 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMessageAttrs(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Initial     MessageAttrs
+		AddAttrs    []MessageAttr
+		RemoveAttrs []MessageAttr
+		Exp         MessageAttrs
+		ExpSlice    []MessageAttr
+	}{
+		{
+			Name: "basic",
+			AddAttrs: []MessageAttr{
+				TxMessageAttr,
+				AgentToServerMessageAttr,
+			},
+			Exp:      MessageAttrs(TxMessageAttr | AgentToServerMessageAttr),
+			ExpSlice: []MessageAttr{TxMessageAttr, AgentToServerMessageAttr},
+		},
+		{
+			Name:     "add to existing",
+			Initial:  MessageAttrs(RxMessageAttr | ServerToAgentMessageAttr),
+			AddAttrs: []MessageAttr{ErrorMessageAttr},
+			Exp:      MessageAttrs(RxMessageAttr | ServerToAgentMessageAttr | ErrorMessageAttr),
+			ExpSlice: []MessageAttr{RxMessageAttr, ServerToAgentMessageAttr, ErrorMessageAttr},
+		},
+		{
+			Name:        "remove from existing",
+			Initial:     MessageAttrs(RxMessageAttr | ServerToAgentMessageAttr),
+			RemoveAttrs: []MessageAttr{RxMessageAttr},
+			Exp:         MessageAttrs(ServerToAgentMessageAttr),
+			ExpSlice:    []MessageAttr{ServerToAgentMessageAttr},
+		},
+		{
+			Name:        "add and remove",
+			Initial:     MessageAttrs(RxMessageAttr | ServerToAgentMessageAttr),
+			RemoveAttrs: []MessageAttr{RxMessageAttr, ServerToAgentMessageAttr},
+			AddAttrs:    []MessageAttr{TxMessageAttr, AgentToServerMessageAttr},
+			Exp:         MessageAttrs(TxMessageAttr | AgentToServerMessageAttr),
+			ExpSlice:    []MessageAttr{TxMessageAttr, AgentToServerMessageAttr},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			initial := test.Initial
+			for _, attr := range test.AddAttrs {
+				initial.Set(attr)
+			}
+			for _, attr := range test.RemoveAttrs {
+				initial.Unset(attr)
+			}
+			if got, want := initial, test.Exp; got != want {
+				t.Errorf("bad MessageAttrs: got %v, want %v", got, want)
+			}
+			if got, want := test.Exp.Slice(), test.ExpSlice; !cmp.Equal(got, want) {
+				t.Errorf("bad []MessageAttr: %s", cmp.Diff(want, got))
+			}
+		})
+	}
+}

--- a/client/types/ringbuffer.go
+++ b/client/types/ringbuffer.go
@@ -1,0 +1,62 @@
+package types
+
+import "sync"
+
+// RingBuffer is a simple goroutine-safe ring buffer.
+type RingBuffer[T any] struct {
+	buffer   []T
+	capacity int
+	offset   int
+	mu       sync.Mutex
+}
+
+// NewRingBuffer creates a new RingBuffer with a set capacity.
+func NewRingBuffer[T any](capacity int) *RingBuffer[T] {
+	return &RingBuffer[T]{
+		capacity: capacity,
+	}
+}
+
+// Insert puts a new item into the RingBuffer.
+func (r *RingBuffer[T]) Insert(item T) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.buffer) < r.capacity {
+		r.buffer = append(r.buffer, item)
+	} else {
+		r.buffer[r.offset] = item
+		r.offset = (r.offset + 1) % r.capacity
+	}
+}
+
+func (r *RingBuffer[T]) read(into []T) int {
+	if len(into) > len(r.buffer) {
+		into = into[:len(r.buffer)]
+	}
+	for i := range into {
+		into[i] = r.buffer[(r.offset+i)%len(r.buffer)]
+	}
+	return len(into)
+}
+
+// Read reads the items of the RingBuffer in the order they were inserted in.
+func (r *RingBuffer[T]) Read(into []T) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.read(into)
+}
+
+// Drain reads all of the items in the RingBuffer and resets the RingBuffer's
+// internal buffer and offset.
+func (r *RingBuffer[T]) Drain() []T {
+	result := make([]T, r.capacity)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	read := r.read(result)
+	r.buffer = r.buffer[:0]
+	r.offset = 0
+
+	return result[:read]
+}

--- a/client/types/ringbuffer_test.go
+++ b/client/types/ringbuffer_test.go
@@ -1,0 +1,120 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRingBufferReadWrite(t *testing.T) {
+	tests := []struct {
+		Name    string
+		Cap     int
+		ReadCap int
+		Insert  []int
+		Exp     []int
+	}{
+		{
+			Name:    "less than capacity",
+			Cap:     10,
+			ReadCap: 5,
+			Insert:  []int{1, 2, 3, 4, 5},
+			Exp:     []int{1, 2, 3, 4, 5},
+		},
+		{
+			Name:    "more than capacity",
+			Cap:     5,
+			ReadCap: 5,
+			Insert:  []int{1, 2, 3, 4, 5, 6, 7, 8},
+			Exp:     []int{4, 5, 6, 7, 8},
+		},
+		{
+			Name:    "equal to capacity",
+			Cap:     5,
+			ReadCap: 5,
+			Insert:  []int{1, 2, 3, 4, 5},
+			Exp:     []int{1, 2, 3, 4, 5},
+		},
+		{
+			Name:    "read capacity greater than capacity",
+			Cap:     5,
+			ReadCap: 10,
+			Insert:  []int{1, 2, 3, 4, 5},
+			Exp:     []int{1, 2, 3, 4, 5, 0, 0, 0, 0, 0},
+		},
+		{
+			Name:    "read capacity smaller than capacity",
+			Cap:     5,
+			ReadCap: 3,
+			Insert:  []int{1, 2, 3, 4, 5},
+			Exp:     []int{1, 2, 3},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			buf := NewRingBuffer[int](test.Cap)
+			for _, item := range test.Insert {
+				buf.Insert(item)
+			}
+			got := make([]int, test.ReadCap)
+			read := buf.Read(got)
+			if !cmp.Equal(got, test.Exp) {
+				t.Errorf("bad read: %v", cmp.Diff(test.Exp, got))
+			}
+			expReadLen := test.Cap
+			if expReadLen > test.ReadCap {
+				expReadLen = test.ReadCap
+			}
+			if got, want := read, expReadLen; got != want {
+				t.Error(expReadLen)
+				t.Errorf("bad read length: got %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestRingBufferDrain(t *testing.T) {
+	tests := []struct {
+		Name    string
+		Cap     int
+		ReadCap int
+		Insert  []int
+		Exp     []int
+	}{
+		{
+			Name:    "less than capacity",
+			Cap:     10,
+			ReadCap: 5,
+			Insert:  []int{1, 2, 3, 4, 5},
+			Exp:     []int{1, 2, 3, 4, 5},
+		},
+		{
+			Name:    "more than capacity",
+			Cap:     5,
+			ReadCap: 5,
+			Insert:  []int{1, 2, 3, 4, 5, 6, 7, 8},
+			Exp:     []int{4, 5, 6, 7, 8},
+		},
+		{
+			Name:    "equal to capacity",
+			Cap:     5,
+			ReadCap: 5,
+			Insert:  []int{1, 2, 3, 4, 5},
+			Exp:     []int{1, 2, 3, 4, 5},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			buf := NewRingBuffer[int](test.Cap)
+			for _, item := range test.Insert {
+				buf.Insert(item)
+			}
+			got := buf.Drain()
+			if !cmp.Equal(got, test.Exp) {
+				t.Errorf("bad drain: got %v, want %v", got, test.Exp)
+			}
+		})
+	}
+}

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -64,4 +64,8 @@ type StartSettings struct {
 	//
 	// If the ReportsHeartbeat capability is disabled, this option has no effect.
 	HeartbeatInterval *time.Duration
+
+	// Metrics are opamp-specific internal metrics such as latency and
+	// bandwidth measurements.
+	Metrics *ClientMetrics
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/stretchr/testify v1.10.0
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/server/httpconnection.go
+++ b/server/httpconnection.go
@@ -29,10 +29,10 @@ func (c httpConnection) Connection() net.Conn {
 
 var _ types.Connection = (*httpConnection)(nil)
 
-func (c httpConnection) Send(_ context.Context, _ *protobufs.ServerToAgent) error {
+func (c httpConnection) Send(_ context.Context, _ *protobufs.ServerToAgent) (int, error) {
 	// Send() should not be called for plain HTTP connection. Instead, the response will
 	// be sent after the onMessage callback returns.
-	return ErrInvalidHTTPConnection
+	return 0, ErrInvalidHTTPConnection
 }
 
 func (c httpConnection) Disconnect() error {

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -260,7 +260,7 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 			}
 			sentCustomCapabilities = true
 		}
-		err = agentConn.Send(msgContext, response)
+		_, err = agentConn.Send(msgContext, response)
 		if err != nil {
 			s.logger.Errorf(msgContext, "Cannot send message to WebSocket: %v", err)
 		}

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -1016,7 +1016,7 @@ func BenchmarkSendToClient(b *testing.B) {
 	cancel()
 
 	for _, conn := range serverConnections {
-		err := conn.Send(context.Background(), &protobufs.ServerToAgent{})
+		_, err := conn.Send(context.Background(), &protobufs.ServerToAgent{})
 
 		if err != nil {
 			b.Error(err)

--- a/server/types/connection.go
+++ b/server/types/connection.go
@@ -18,7 +18,8 @@ type Connection interface {
 	// connections.
 	// Blocks until the message is sent.
 	// Should return as soon as possible if the ctx is cancelled.
-	Send(ctx context.Context, message *protobufs.ServerToAgent) error
+	// Returns the number of bytes written and any error encountered.
+	Send(ctx context.Context, message *protobufs.ServerToAgent) (int, error)
 
 	// Disconnect closes the network connection.
 	// Any blocked Read or Write operations will be unblocked and return errors.

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -5,8 +5,6 @@ import (
 	"net"
 	"sync"
 
-	"github.com/gorilla/websocket"
-
 	"github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/open-telemetry/opamp-go/server/types"
@@ -18,7 +16,7 @@ type wsConnection struct {
 	// so ensure that we only have a single operation in progress at a time.
 	// For more: https://pkg.go.dev/github.com/gorilla/websocket#hdr-Concurrency
 	connMutex *sync.Mutex
-	wsConn    *websocket.Conn
+	wsConn    internal.WebsocketConn
 }
 
 var _ types.Connection = (*wsConnection)(nil)
@@ -27,7 +25,7 @@ func (c wsConnection) Connection() net.Conn {
 	return c.wsConn.UnderlyingConn()
 }
 
-func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) error {
+func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) (int, error) {
 	c.connMutex.Lock()
 	defer c.connMutex.Unlock()
 


### PR DESCRIPTION
**Not ready for merge**

I've opened this PR in order to spur some discussion on how metrics could be reported by opamp-go clients and servers without introducing a dependency on open-telemetry or another metrics library. The goal here is to let library users inspect opamp-go's internal client metrics.

This PR adds client-side metrics collection for WS and HTTP transports. Collected metrics are in a custom format that can be translated to other metrics definitions by the library user. A TODO at this point is to add some library routines that can translate these metrics into common formats. It's unclear to me exactly where that should happen at the moment.

Counters have been added for message transmission metadata, as well as a ringbuffer that collects message latencies as well as key message attributes.

Library users can pass a `types.ClientMetrics` object to `StartSettings` and then inspect the results periodically. The methods that the counters and ringbuffers expose are goroutine-safe. If the metrics object is not passed, a default one with a minimal buffer is created, so this change should non-breaking for library users.

Some implementation details have been modified in order to ease testing. Specifically, some internal types have been replaced with interfaces in senders and receivers so that they can be replaced with fakes in tests.

The use of `*websocket.Conn` has been replaced with `internal.WebsocketConn` in several places for this reason as well.

Finally, some definitions of the server have changed in order to reflect the need for the number of bytes transmitted to be known by the caller. While this is not necessary for client-side metrics collection, it will help facilitate a similar change to the server so that metrics can be collected there too.

If this change or a change like it is merged, then we could also implement this part of the spec, building on top of the internal collection: https://github.com/observIQ/opamp-spec/blob/808917457e973c251fd6c968bbb2b9dd38cb9f3d/specification.md#own-telemetry-reporting (thanks @rnishtala-sumo for the suggestion)