### PR TITLE
fix: wait for HTTP server serve() termination

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -73,8 +73,9 @@ type OpAMPServer interface {
 	// accept connections.
 	Start(settings StartSettings) error
 
-	// Stop accepting new connections and close all current connections. This should
-	// block until all connections are closed.
+	// Stop accepting new connections and close all current connections.
+	// This operation should block until both the server socket and all
+	// connections have been closed.
 	Stop(ctx context.Context) error
 
 	// Addr returns the network address Server is listening on. Nil if not started.

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -174,7 +174,12 @@ func (s *server) Stop(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		s.httpServerServeWg.Wait()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			s.httpServerServeWg.Wait()
+		}
 	}
 	return nil
 }

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -40,7 +40,8 @@ type server struct {
 
 	// The listening HTTP Server after successful Start() call. Nil if Start()
 	// is not called or was not successful.
-	httpServer *http.Server
+	httpServer        *http.Server
+	httpServerServeWg *sync.WaitGroup
 
 	// The network address Server is listening on. Nil if not started.
 	addr net.Addr
@@ -109,6 +110,9 @@ func (s *server) Start(settings StartSettings) error {
 		ConnContext: contextWithConn,
 	}
 	s.httpServer = hs
+	httpServerServeWg := sync.WaitGroup{}
+	httpServerServeWg.Add(1)
+	s.httpServerServeWg = &httpServerServeWg
 
 	listenAddr := s.httpServer.Addr
 
@@ -119,7 +123,10 @@ func (s *server) Start(settings StartSettings) error {
 		}
 		err = s.startHttpServer(
 			listenAddr,
-			func(l net.Listener) error { return hs.ServeTLS(l, "", "") },
+			func(l net.Listener) error {
+				defer httpServerServeWg.Done()
+				return hs.ServeTLS(l, "", "")
+			},
 		)
 	} else {
 		if listenAddr == "" {
@@ -127,7 +134,10 @@ func (s *server) Start(settings StartSettings) error {
 		}
 		err = s.startHttpServer(
 			listenAddr,
-			func(l net.Listener) error { return hs.Serve(l) },
+			func(l net.Listener) error {
+				defer httpServerServeWg.Done()
+				return hs.Serve(l)
+			},
 		)
 	}
 	return err
@@ -160,7 +170,11 @@ func (s *server) Stop(ctx context.Context) error {
 		defer func() { s.httpServer = nil }()
 		// This stops accepting new connections. TODO: close existing
 		// connections and wait them to be terminated.
-		return s.httpServer.Shutdown(ctx)
+		err := s.httpServer.Shutdown(ctx)
+		if err != nil {
+			return err
+		}
+		s.httpServerServeWg.Wait()
 	}
 	return nil
 }

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -57,6 +57,19 @@ func TestServerStartStop(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestServerStartStopWithCancel(t *testing.T) {
+	srv := startServer(t, &StartSettings{})
+
+	err := srv.Start(StartSettings{})
+	assert.ErrorIs(t, err, errAlreadyStarted)
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = srv.Stop(canceledCtx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestServerStartStopIdempotency(t *testing.T) {
 	endpoint := testhelpers.GetAvailableLocalAddress()
 	for i := 0; i < 10; i++ {

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -57,6 +57,23 @@ func TestServerStartStop(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestServerStartStopIdempotency(t *testing.T) {
+	endpoint := testhelpers.GetAvailableLocalAddress()
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("Attempt #%d: ", i), func(t *testing.T) {
+			srv := startServer(t, &StartSettings{
+				ListenEndpoint: endpoint,
+			})
+
+			err := srv.Start(StartSettings{})
+			assert.ErrorIs(t, err, errAlreadyStarted)
+
+			err = srv.Stop(context.Background())
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestServerStartStopWithMiddleware(t *testing.T) {
 	var addedMiddleware atomic.Bool
 	assert.False(t, addedMiddleware.Load())


### PR DESCRIPTION
 Fixes https://github.com/open-telemetry/opamp-go/issues/347