### PR TITLE
Use optional headers from DownloadableFile messages

### DIFF
--- a/client/internal/packagessyncer.go
+++ b/client/internal/packagessyncer.go
@@ -280,6 +280,12 @@ func (s *packagesSyncer) downloadFile(ctx context.Context, pkgName string, file 
 		return fmt.Errorf("cannot download file from %s: %v", file.DownloadUrl, err)
 	}
 
+	if file.Headers != nil && len(file.Headers.Headers) > 0 {
+		for _, h := range file.Headers.Headers {
+			req.Header.Add(h.GetKey(), h.GetValue())
+		}
+	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("cannot download file from %s: %v", file.DownloadUrl, err)


### PR DESCRIPTION
This PR wires in the optional headers available in the DownloadableFile message to the request, if they're present.

I think there's a couple different ways to test this, I believe that's the more straightforward one, but I can look at alternatives if you'd like to keep `createDownloadSrv` as-is.