### PR TITLE
fix: Add atomic.Bool to ensure wsConnection.Disconnect() is only called once

### DIFF
--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
@@ -225,12 +226,12 @@ func (s *server) httpHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Conn, connectionCallbacks *serverTypes.ConnectionCallbacks) {
-	agentConn := wsConnection{wsConn: wsConn, connMutex: &sync.Mutex{}}
+	agentConn := wsConnection{wsConn: wsConn, connMutex: &sync.Mutex{}, closed: &atomic.Bool{}}
 
 	defer func() {
 		// Close the connection when all is done.
 		defer func() {
-			err := wsConn.Close()
+			err := agentConn.Disconnect()
 			if err != nil {
 				s.logger.Errorf(context.Background(), "error closing the WebSocket connection: %v", err)
 			}

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"sync"
-	"sync/atomic"
 
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
@@ -226,7 +225,7 @@ func (s *server) httpHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Conn, connectionCallbacks *serverTypes.ConnectionCallbacks) {
-	agentConn := wsConnection{wsConn: wsConn, connMutex: &sync.Mutex{}, closed: &atomic.Bool{}}
+	agentConn := newWSConnection(wsConn)
 
 	defer func() {
 		// Close the connection when all is done.

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -30,7 +30,6 @@ import (
 
 func startServer(t *testing.T, settings *StartSettings) *server {
 	return startServerWithLogger(t, settings, &sharedinternal.NopLogger{})
-
 }
 
 func startServerWithLogger(t *testing.T, settings *StartSettings, logger clienttypes.Logger) *server {

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -273,7 +273,7 @@ func TestDisconnectClientWSConnection(t *testing.T) {
 	assert.True(t, atomic.LoadInt32(&connectionCloseCalled) == 0)
 
 	// Close connection from client side
-	clientConn := wsConnection{wsConn: conn, connMutex: &sync.Mutex{}, closed: &atomic.Bool{}}
+	clientConn := newWSConnection(conn)
 	err = clientConn.Disconnect()
 	assert.NoError(t, err)
 

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -288,23 +288,25 @@ func TestDisconnectClientWSConnection(t *testing.T) {
 
 // testLogger is a struct that adapts a *zap.Logger to opamp-go's Logger interface.
 type testLogger struct {
-	logs []string
+	errorLogs []string
+	debugLogs []string
 }
 
 func newTestLogger() *testLogger {
 	return &testLogger{
-		logs: []string{},
+		errorLogs: []string{},
+		debugLogs: []string{},
 	}
 }
 
 func (o *testLogger) Debugf(_ context.Context, format string, v ...any) {
 	log := fmt.Sprintf(format, v...)
-	o.logs = append(o.logs, fmt.Sprintf("Debugf: %s\n", log))
+	o.debugLogs = append(o.debugLogs, fmt.Sprintf("Debugf: %s\n", log))
 }
 
 func (o *testLogger) Errorf(_ context.Context, format string, v ...any) {
 	log := fmt.Sprintf(format, v...)
-	o.logs = append(o.logs, fmt.Sprintf("Errorf: %s\n", log))
+	o.errorLogs = append(o.errorLogs, fmt.Sprintf("Errorf: %s\n", log))
 }
 
 func TestDisconnectServerWSConnection(t *testing.T) {
@@ -352,9 +354,8 @@ func TestDisconnectServerWSConnection(t *testing.T) {
 		return err != nil
 	})
 
-	require.Equal(t, 1, len(logger.logs))
-	require.Contains(t, logger.logs[0], "Errorf: Cannot read a message from WebSocket: read tcp")
-	require.Contains(t, logger.logs[0], "use of closed network connection")
+	// We expect exactly one error log
+	require.Equal(t, 1, len(logger.errorLogs))
 }
 
 var testInstanceUid = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6}

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -26,7 +26,7 @@ type wsConnection struct {
 var _ types.Connection = (*wsConnection)(nil)
 
 func newWSConnection(wsConn *websocket.Conn) types.Connection {
-	return &wsConnection{wsConn: wsConn, connMutex: sync.Mutex{}, closed: atomic.Bool{}}
+	return &wsConnection{wsConn: wsConn}
 }
 
 func (c *wsConnection) Connection() net.Conn {

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -37,9 +37,8 @@ func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) 
 }
 
 func (c wsConnection) Disconnect() error {
-	if c.closed.Load() {
+	if !c.closed.CompareAndSwap(false, true) {
 		return nil
 	}
-	c.closed.Store(true)
 	return c.wsConn.Close()
 }

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -18,25 +18,29 @@ type wsConnection struct {
 	// The websocket library does not allow multiple concurrent write operations,
 	// so ensure that we only have a single operation in progress at a time.
 	// For more: https://pkg.go.dev/github.com/gorilla/websocket#hdr-Concurrency
-	connMutex *sync.Mutex
+	connMutex sync.Mutex
 	wsConn    *websocket.Conn
-	closed    *atomic.Bool
+	closed    atomic.Bool
 }
 
 var _ types.Connection = (*wsConnection)(nil)
 
-func (c wsConnection) Connection() net.Conn {
+func newWSConnection(wsConn *websocket.Conn) types.Connection {
+	return &wsConnection{wsConn: wsConn, connMutex: sync.Mutex{}, closed: atomic.Bool{}}
+}
+
+func (c *wsConnection) Connection() net.Conn {
 	return c.wsConn.UnderlyingConn()
 }
 
-func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) error {
+func (c *wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) error {
 	c.connMutex.Lock()
 	defer c.connMutex.Unlock()
 
 	return internal.WriteWSMessage(c.wsConn, message)
 }
 
-func (c wsConnection) Disconnect() error {
+func (c *wsConnection) Disconnect() error {
 	if !c.closed.CompareAndSwap(false, true) {
 		return nil
 	}


### PR DESCRIPTION
Addresses this [issue](https://github.com/open-telemetry/opamp-go/issues/358) by addding an atomic.Bool so we only close the underlying websocket connection once. This PR also adds the test `TestDisconnectServerWSConnection` to ensure that that error log isn't generated when the connection is closed server-side. I renamed `TestDisconnectWSConnection` to `TestDisconnectClientWSConnection` since it tests closing the connection from the client-side, though the comments in the test implied it tested disconnecting from the server.

Perhaps it would be better to simply ignore the error when we close the connection twice? I'm unsure if there are error conditions where we'd want to be able to try to close the connection again.

Resolves https://github.com/open-telemetry/opamp-go/issues/358