### PR TITLE
Bindplane brand update

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Emeritus Approvers
 
 Maintainers ([@open-telemetry/opamp-go-maintainers](https://github.com/orgs/open-telemetry/teams/opamp-go-maintainers)):
 
-- [Andy Keller](https://github.com/andykellr), observIQ
+- [Andy Keller](https://github.com/andykellr), Bindplane
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).


### PR DESCRIPTION
observIQ is now Bindplane