### PR TITLE
feat: Define connectionType for server

### DIFF
--- a/server/httpconnection.go
+++ b/server/httpconnection.go
@@ -35,6 +35,10 @@ func (c httpConnection) Send(_ context.Context, _ *protobufs.ServerToAgent) erro
 	return ErrInvalidHTTPConnection
 }
 
+func (c httpConnection) Type() types.ConnectionType {
+	return types.ConnectionTypeHTTP
+}
+
 func (c httpConnection) Disconnect() error {
 	// Disconnect() should not be called for plain HTTP connection.
 	return ErrInvalidHTTPConnection

--- a/server/types/connection.go
+++ b/server/types/connection.go
@@ -7,11 +7,26 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
+const (
+	// ConnectionTypeHTTP is the type of a plain HTTP connection.
+	ConnectionTypeHTTP ConnectionType = "http"
+	// ConnectionTypeWebSocket is the type of a WebSocket connection.
+	ConnectionTypeWebSocket ConnectionType = "websocket"
+)
+
+// ConnectionType is the type of a connection.
+// It can be one of ConnectionTypeHTTP or ConnectionTypeWebSocket.
+type ConnectionType string
+
 // Connection represents one OpAMP connection.
 // The implementation MUST be a comparable type so that it can be used as a map key.
 type Connection interface {
 	// Connection returns the underlying net.Conn
 	Connection() net.Conn
+
+	// Type returns the type of the connection.
+	// The type is one of http, websocket, or unknown.
+	Type() ConnectionType
 
 	// Send a message. Should not be called concurrently for the same Connection instance.
 	// Can be called only for WebSocket connections. Will return an error for plain HTTP

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -27,6 +27,10 @@ func (c wsConnection) Connection() net.Conn {
 	return c.wsConn.UnderlyingConn()
 }
 
+func (c wsConnection) Type() types.ConnectionType {
+	return types.ConnectionTypeWebSocket
+}
+
 func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) error {
 	c.connMutex.Lock()
 	defer c.connMutex.Unlock()


### PR DESCRIPTION
- In the opamp-spec document, the connection type is http or websocket.
  - ref. https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#communication-model

> OpAMP protocol works over one of the 2 supported transports: plain HTTP connections and WebSocket connections.

- To define OpAMP server, a developer should be define `ConnectionCallbacks` and manage connections using `OnConnected` and `OnConnectionClose`. However, a way to handle the two type of connections are different.:
  - For example, http connection cannot send message, so if the server want to send `ServerToAgent` message, wait for the its next connection. (= next polling)

- So, IMO, the `Connection` provides a method to find connection type.