### PR TITLE
fix: Send AgentToServer.agent_disconnect when client is stopped.

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -516,15 +516,23 @@ func TestFirstStatusReport(t *testing.T) {
 
 		// Start a Server.
 		srv := internal.StartMockServer(t)
+		var isFirstSrvMessage atomic.Bool
+		isFirstSrvMessage.Store(true)
 		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
-			assert.EqualValues(t, 0, msg.SequenceNum)
-			return &protobufs.ServerToAgent{
-				InstanceUid:  msg.InstanceUid,
-				RemoteConfig: remoteConfig,
+			if isFirstSrvMessage.Load() {
+				isFirstSrvMessage.Store(false)
+				assert.EqualValues(t, 0, msg.SequenceNum)
+				return &protobufs.ServerToAgent{
+					InstanceUid:  msg.InstanceUid,
+					RemoteConfig: remoteConfig,
+				}
 			}
+			return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
 		}
 
 		// Start a client.
+		var isFirstClientMessage atomic.Bool
+		isFirstClientMessage.Store(true)
 		var connected, remoteConfigReceived int64
 		settings := types.StartSettings{
 			Callbacks: types.Callbacks{
@@ -532,10 +540,13 @@ func TestFirstStatusReport(t *testing.T) {
 					atomic.AddInt64(&connected, 1)
 				},
 				OnMessage: func(ctx context.Context, msg *types.MessageData) {
-					// Verify that the client received exactly the remote config that
-					// the Server sent.
-					assert.True(t, proto.Equal(remoteConfig, msg.RemoteConfig))
-					atomic.AddInt64(&remoteConfigReceived, 1)
+					if isFirstClientMessage.Load() {
+						isFirstClientMessage.Store(false)
+						// Verify that the client received exactly the remote config that
+						// the Server sent.
+						assert.True(t, proto.Equal(remoteConfig, msg.RemoteConfig))
+						atomic.AddInt64(&remoteConfigReceived, 1)
+					}
 				},
 			},
 			Capabilities: protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig,

--- a/client/internal/mockserver.go
+++ b/client/internal/mockserver.go
@@ -63,7 +63,7 @@ func newMockServer(t *testing.T) (*MockServer, *http.ServeMux) {
 				return
 			}
 
-			srv.handleWebSocket(t, w, r)
+			srv.handleWebSocket(w, r)
 		},
 	)
 
@@ -137,7 +137,7 @@ func (m *MockServer) EnableCompression() {
 	m.enableCompression = true
 }
 
-func (m *MockServer) handleWebSocket(t *testing.T, w http.ResponseWriter, r *http.Request) {
+func (m *MockServer) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	upgrader := websocket.Upgrader{
 		EnableCompression: m.enableCompression,
 	}
@@ -155,7 +155,7 @@ func (m *MockServer) handleWebSocket(t *testing.T, w http.ResponseWriter, r *htt
 		if messageType, msgBytes, err = conn.ReadMessage(); err != nil {
 			return
 		}
-		assert.EqualValues(t, websocket.BinaryMessage, messageType)
+		assert.EqualValues(m.t, websocket.BinaryMessage, messageType)
 
 		if len(msgBytes) > 0 && msgBytes[0] == 0 {
 			// New message format. The Protobuf message is preceded by a zero byte header.

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -116,6 +116,13 @@ func (c *wsClient) Start(ctx context.Context, settings types.StartSettings) erro
 }
 
 func (c *wsClient) Stop(ctx context.Context) error {
+	// AgentDisconnect MUST be set in the last AgentToServer message sent from the Client to the Server.
+	c.sender.NextMessage().Update(
+		func(msg *protobufs.AgentToServer) {
+			msg.AgentDisconnect = &protobufs.AgentDisconnect{}
+		},
+	)
+	c.sender.ScheduleSend()
 	return c.common.Stop(ctx)
 }
 


### PR DESCRIPTION
- In the [opamp-spec document](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agenttoserveragent_disconnect), 
  > AgentDisconnect MUST be set in the last AgentToServer message sent from the Client to the Server.

- But, currently there is no implementation for it.
  - Because of it, the below issue occurs.
    - https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39676

- To resolve it, ensure to send `AgentToServer.agent_disconnect` when the client's `Stop()`.

[Edit]
related to #179 

[Edit - 2]
- To ensure to send last scheduled message, when client is stopped.