### PR TITLE
Explicitly close resp.Body in retry loop

### DIFF
--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -213,6 +213,9 @@ func (h *HTTPSender) sendRequestWithRetries(ctx context.Context) (*http.Response
 					case http.StatusTooManyRequests, http.StatusServiceUnavailable:
 						interval = recalculateInterval(interval, resp)
 						err = fmt.Errorf("server response code=%d", resp.StatusCode)
+						if cerr := resp.Body.Close(); cerr != nil {
+							h.logger.Errorf(ctx, "cannot close response body: %v", cerr)
+						}
 
 					default:
 						return nil, fmt.Errorf("invalid response from server: %d", resp.StatusCode)
@@ -289,11 +292,15 @@ func (h *HTTPSender) prepareRequest(ctx context.Context) (*requestWrapper, error
 func (h *HTTPSender) receiveResponse(ctx context.Context, resp *http.Response) {
 	msgBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		_ = resp.Body.Close()
+		if cerr := resp.Body.Close(); cerr != nil {
+			h.logger.Errorf(ctx, "cannot close response body: %v", cerr)
+		}
 		h.logger.Errorf(ctx, "cannot read response body: %v", err)
 		return
 	}
-	_ = resp.Body.Close()
+	if cerr := resp.Body.Close(); cerr != nil {
+		h.logger.Errorf(ctx, "cannot close response body: %v", cerr)
+	}
 
 	var response protobufs.ServerToAgent
 	if err := proto.Unmarshal(msgBytes, &response); err != nil {


### PR DESCRIPTION
https://github.com/open-telemetry/opamp-go/issues/387

Without fix :
As following it will show  number of BOUND connections for retrial after getting 503's

![06_07_41](https://github.com/user-attachments/assets/3c4e75ac-c29b-4c8e-8ce1-5418ddb7d380)

After Fix :
we see BOUND connections ports are being released 
![06_08_01](https://github.com/user-attachments/assets/651f633e-8a35-4291-bdcc-35635201a2f6)
