### PR TITLE
chore(deps): bump go to v1.24

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -23,7 +23,7 @@ jobs:
       - id: install_go
         uses: WillAbides/setup-go-faster@v1.14.0
         with:
-          go-version: "1.22.x"
+          go-version: "1.24.x"
       - uses: dominikh/staticcheck-action@v1.3.1
         with:
           install-go: false

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.5.0
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opamp-go
 
-go 1.22
+go 1.24.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/internal/examples/go.mod
+++ b/internal/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opamp-go/internal/examples
 
-go 1.22
+go 1.24.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/internal/examples/supervisor/main.go
+++ b/internal/examples/supervisor/main.go
@@ -13,7 +13,7 @@ func main() {
 	logger := &supervisor.Logger{Logger: log.Default()}
 	supervisor, err := supervisor.NewSupervisor(logger)
 	if err != nil {
-		logger.Errorf(context.Background(), err.Error())
+		logger.Errorf(context.Background(), "%s", err.Error())
 		os.Exit(-1)
 		return
 	}

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opamp-go/internal/tools
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.1
 


### PR DESCRIPTION
Standardizes all of the `go.mod` files to 1.24 and bumps the appropriate GitHub workflows. Addresses a single format error when bumping to v1.24.

Resolves #399 and replaces #394 