### PR TITLE
Plumb TLS Config to Package Syncer

### DIFF
--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -58,6 +58,7 @@ type HTTPSender struct {
 	url                string
 	logger             types.Logger
 	client             *http.Client
+	tlsConfig          *tls.Config
 	callbacks          types.Callbacks
 	pollingIntervalMs  int64
 	compressionEnabled bool
@@ -101,7 +102,9 @@ func (h *HTTPSender) Run(
 ) {
 	h.url = url
 	h.callbacks = callbacks
-	h.receiveProcessor = newReceivedProcessor(h.logger, callbacks, h, clientSyncedState, packagesStateProvider, capabilities, packageSyncMutex, reporterInterval)
+	h.receiveProcessor = newReceivedProcessor(
+		h.logger, callbacks, h, h.tlsConfig, clientSyncedState, packagesStateProvider, capabilities, packageSyncMutex, reporterInterval,
+	)
 
 	// we need to detect if the redirect was ever set, if not, we want default behaviour
 	if callbacks.CheckRedirect != nil {
@@ -330,6 +333,7 @@ func (h *HTTPSender) EnableCompression() {
 
 func (h *HTTPSender) AddTLSConfig(config *tls.Config) {
 	if config != nil {
+		h.tlsConfig = config
 		h.client.Transport = &http.Transport{
 			TLSClientConfig: config,
 		}

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -202,7 +202,7 @@ func TestRequestInstanceUidFlagReset(t *testing.T) {
 	clientSyncedState := &ClientSyncedState{}
 	clientSyncedState.SetFlags(protobufs.AgentToServerFlags_AgentToServerFlags_RequestInstanceUid)
 	capabilities := protobufs.AgentCapabilities_AgentCapabilities_Unspecified
-	sender.receiveProcessor = newReceivedProcessor(&sharedinternal.NopLogger{}, sender.callbacks, sender, clientSyncedState, nil, capabilities, new(sync.Mutex), time.Second)
+	sender.receiveProcessor = newReceivedProcessor(&sharedinternal.NopLogger{}, sender.callbacks, sender, sender.tlsConfig, clientSyncedState, nil, capabilities, new(sync.Mutex), time.Second)
 
 	// If we process a message with a nil AgentIdentification, or an incorrect NewInstanceUid.
 	sender.receiveProcessor.ProcessReceivedMessage(ctx,
@@ -258,7 +258,7 @@ func TestPackageUpdatesInParallel(t *testing.T) {
 
 	clientSyncedState := &ClientSyncedState{}
 	capabilities := protobufs.AgentCapabilities_AgentCapabilities_AcceptsPackages
-	sender.receiveProcessor = newReceivedProcessor(&sharedinternal.NopLogger{}, sender.callbacks, sender, clientSyncedState, localPackageState, capabilities, &mux, time.Second)
+	sender.receiveProcessor = newReceivedProcessor(&sharedinternal.NopLogger{}, sender.callbacks, sender, sender.tlsConfig, clientSyncedState, localPackageState, capabilities, &mux, time.Second)
 
 	sender.receiveProcessor.ProcessReceivedMessage(ctx,
 		&protobufs.ServerToAgent{
@@ -331,7 +331,7 @@ func TestPackageUpdatesWithError(t *testing.T) {
 	clientSyncedState := &ClientSyncedState{}
 
 	capabilities := protobufs.AgentCapabilities_AgentCapabilities_AcceptsPackages
-	sender.receiveProcessor = newReceivedProcessor(&sharedinternal.NopLogger{}, sender.callbacks, sender, clientSyncedState, localPackageState, capabilities, &mux, time.Second)
+	sender.receiveProcessor = newReceivedProcessor(&sharedinternal.NopLogger{}, sender.callbacks, sender, sender.tlsConfig, clientSyncedState, localPackageState, capabilities, &mux, time.Second)
 
 	// Send two messages in parallel.
 	sender.receiveProcessor.ProcessReceivedMessage(ctx,

--- a/client/internal/packagessyncer_test.go
+++ b/client/internal/packagessyncer_test.go
@@ -1,0 +1,53 @@
+package internal
+
+import (
+	"crypto/tls"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	sharedinternal "github.com/open-telemetry/opamp-go/internal"
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageSyncer_New(t *testing.T) {
+	tests := []struct {
+		name      string
+		tlsConfig *tls.Config
+	}{
+		{
+			name:      "without TLS",
+			tlsConfig: nil,
+		},
+		{
+			name:      "with TLS",
+			tlsConfig: &tls.Config{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := &sharedinternal.NopLogger{}
+			syncer := NewPackagesSyncer(
+				logger,
+				&protobufs.PackagesAvailable{},
+				NewHTTPSender(logger),
+				tt.tlsConfig,
+				&ClientSyncedState{},
+				NewInMemPackagesStore(),
+				&sync.Mutex{},
+				time.Minute,
+			)
+
+			require.NotNil(t, syncer)
+			tr, ok := syncer.httpClient.Transport.(*http.Transport)
+			require.True(t, ok, "Transport should be of type *http.Transport")
+			if tt.tlsConfig != nil {
+				assert.Equal(t, tr.TLSClientConfig, tt.tlsConfig)
+			}
+		})
+	}
+}

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"sync"
 	"time"
@@ -35,12 +36,16 @@ type receivedProcessor struct {
 	// Download reporter interval value
 	// a negative number indicates that the default should be used instead.
 	downloadReporterInt time.Duration
+
+	// tlsConfig is the TLS configuration used to connect to the opamp server.
+	tlsConfig *tls.Config
 }
 
 func newReceivedProcessor(
 	logger types.Logger,
 	callbacks types.Callbacks,
 	sender Sender,
+	tlsConfig *tls.Config,
 	clientSyncedState *ClientSyncedState,
 	packagesStateProvider types.PackagesStateProvider,
 	capabilities protobufs.AgentCapabilities,
@@ -51,6 +56,7 @@ func newReceivedProcessor(
 		logger:                logger,
 		callbacks:             callbacks,
 		sender:                sender,
+		tlsConfig:             tlsConfig,
 		clientSyncedState:     clientSyncedState,
 		packagesStateProvider: packagesStateProvider,
 		capabilities:          capabilities,
@@ -132,6 +138,7 @@ func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *pro
 				r.logger,
 				msgData.PackagesAvailable,
 				r.sender,
+				r.tlsConfig,
 				r.clientSyncedState,
 				r.packagesStateProvider,
 				r.packageSyncMutex,

--- a/client/internal/wsreceiver.go
+++ b/client/internal/wsreceiver.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"sync"
 	"time"
@@ -31,6 +32,7 @@ func NewWSReceiver(
 	callbacks types.Callbacks,
 	conn *websocket.Conn,
 	sender *WSSender,
+	tlsConfig *tls.Config,
 	clientSyncedState *ClientSyncedState,
 	packagesStateProvider types.PackagesStateProvider,
 	capabilities protobufs.AgentCapabilities,
@@ -42,7 +44,7 @@ func NewWSReceiver(
 		logger:    logger,
 		sender:    sender,
 		callbacks: callbacks,
-		processor: newReceivedProcessor(logger, callbacks, sender, clientSyncedState, packagesStateProvider, capabilities, packageSyncMutex, reporterInterval),
+		processor: newReceivedProcessor(logger, callbacks, sender, tlsConfig, clientSyncedState, packagesStateProvider, capabilities, packageSyncMutex, reporterInterval),
 		stopped:   make(chan struct{}),
 	}
 

--- a/client/internal/wsreceiver_test.go
+++ b/client/internal/wsreceiver_test.go
@@ -88,7 +88,7 @@ func TestServerToAgentCommand(t *testing.T) {
 			}
 			sender := WSSender{}
 			capabilities := protobufs.AgentCapabilities_AgentCapabilities_AcceptsRestartCommand
-			receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, &sender, &clientSyncedState, nil, capabilities, new(sync.Mutex), time.Second)
+			receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, &sender, nil, &clientSyncedState, nil, capabilities, new(sync.Mutex), time.Second)
 			receiver.processor.ProcessReceivedMessage(context.Background(), &protobufs.ServerToAgent{
 				Command: test.command,
 			})
@@ -142,7 +142,7 @@ func TestServerToAgentCommandExclusive(t *testing.T) {
 			},
 		}
 		clientSyncedState := ClientSyncedState{}
-		receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, nil, &clientSyncedState, nil, test.capabilities, new(sync.Mutex), time.Second)
+		receiver := NewWSReceiver(TestLogger{t}, callbacks, nil, nil, nil, &clientSyncedState, nil, test.capabilities, new(sync.Mutex), time.Second)
 		receiver.processor.ProcessReceivedMessage(context.Background(), &protobufs.ServerToAgent{
 			Command: &protobufs.ServerToAgentCommand{
 				Type: protobufs.CommandType_CommandType_Restart,
@@ -204,7 +204,7 @@ func TestReceiverLoopStop(t *testing.T) {
 	}
 	sender := WSSender{}
 	capabilities := protobufs.AgentCapabilities_AgentCapabilities_AcceptsRestartCommand
-	receiver := NewWSReceiver(TestLogger{t}, callbacks, conn, &sender, &clientSyncedState, nil, capabilities, new(sync.Mutex), time.Second)
+	receiver := NewWSReceiver(TestLogger{t}, callbacks, conn, &sender, nil, &clientSyncedState, nil, capabilities, new(sync.Mutex), time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
@@ -246,7 +246,7 @@ func TestWSPackageUpdatesInParallel(t *testing.T) {
 	clientSyncedState := &ClientSyncedState{}
 	capabilities := protobufs.AgentCapabilities_AgentCapabilities_AcceptsPackages
 	sender := NewSender(&internal.NopLogger{})
-	receiver := NewWSReceiver(&internal.NopLogger{}, callbacks, nil, sender, clientSyncedState, localPackageState, capabilities, &mux, time.Second)
+	receiver := NewWSReceiver(&internal.NopLogger{}, callbacks, nil, sender, nil, clientSyncedState, localPackageState, capabilities, &mux, time.Second)
 
 	receiver.processor.ProcessReceivedMessage(ctx,
 		&protobufs.ServerToAgent{

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net/http"
 	"net/url"
@@ -37,6 +38,9 @@ type wsClient struct {
 	dialer    websocket.Dialer
 	conn      *websocket.Conn
 	connMutex sync.RWMutex
+
+	// TLS configuration to use when connecting to OpAMP Server.
+	tlsConfig *tls.Config
 
 	// The sender is responsible for sending portion of the OpAMP protocol.
 	sender *internal.WSSender
@@ -88,6 +92,7 @@ func (c *wsClient) Start(ctx context.Context, settings types.StartSettings) erro
 	c.dialer.EnableCompression = settings.EnableCompression
 
 	if settings.TLSConfig != nil {
+		c.tlsConfig = settings.TLSConfig
 		c.url.Scheme = "wss"
 	}
 	c.dialer.TLSClientConfig = settings.TLSConfig
@@ -360,6 +365,7 @@ func (c *wsClient) runOneCycle(ctx context.Context) {
 		c.common.Callbacks,
 		c.conn,
 		c.sender,
+		c.tlsConfig,
 		&c.common.ClientSyncedState,
 		c.common.PackagesStateProvider,
 		c.common.Capabilities,


### PR DESCRIPTION
Package Syncer uses the default HTTP Client from stdlib (http.DefaultClient) and ignores the TLS configuration provided by the user. This means opamp client can correctly uses TLS configuration for everything but fails when it comes to downloading packages. This is important in situtations where a server needs custom TLS config to work correctly.

This commit ensures Package Syncer uses the same TLS config that HTTP and WebSocker clients use to talk to the server.

This is technically a bug fix. Users passing TLS config to StartSettings would expect opamp client to use the settings for all connections which is not true. This PR ensures the client works as configured for all outgoing connections.