### PR TITLE
Fix tidy job and remove unused token

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -8,6 +8,8 @@ permissions:
   contents: read
 jobs:
   setup-environment:
+    permissions:
+      contents: write # to allow pushing changes to the branch
     runs-on: ubuntu-latest
     if: ${{ (github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'renovatebot')) }}
     steps:
@@ -42,8 +44,6 @@ jobs:
           git config user.email 107717825+opentelemetrybot@users.noreply.github.com
           echo "git diff --exit-code || (git add . && git commit -m \"go mod tidy, make all\" && git push)"
           git diff --exit-code || (git add . && git commit -m "go mod tidy, make all" && git push)
-        env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: renovatebot


### PR DESCRIPTION
While reviewing #414, I noticed the token wasn't being used (it's just doing a git push, which uses the auth from the checkout)

Which means https://github.com/open-telemetry/opamp-go/pull/409 broke the workflow, since it restricted the permissions down to read.

This fixes the permissions so it will work again and removes the unused token.

Obsoletes #414