### PR TITLE
Fix incorrect usage of DefaultHttpClient causing data race

### DIFF
--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -14,10 +14,11 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/open-telemetry/opamp-go/internal"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/open-telemetry/opamp-go/client/internal/utils"
 	"github.com/open-telemetry/opamp-go/client/types"
+	"github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
@@ -75,7 +76,7 @@ func NewHTTPSender(logger types.Logger) *HTTPSender {
 	h := &HTTPSender{
 		SenderCommon:      NewSenderCommon(),
 		logger:            logger,
-		client:            http.DefaultClient,
+		client:            utils.NewHttpClient(),
 		pollingIntervalMs: defaultPollingIntervalMs,
 	}
 	// initialize the headers with no additional headers

--- a/client/internal/utils/httpclient.go
+++ b/client/internal/utils/httpclient.go
@@ -1,0 +1,13 @@
+package utils
+
+import "net/http"
+
+func NewHttpClient() *http.Client {
+	client := &http.Client{}
+	// Clone the default transport to avoid being affected by global state changes.
+	if tr, ok := http.DefaultTransport.(*http.Transport); ok {
+		tr = tr.Clone()
+		client.Transport = tr
+	}
+	return client
+}

--- a/client/types/callbacks.go
+++ b/client/types/callbacks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/open-telemetry/opamp-go/client/internal/utils"
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
@@ -163,19 +164,9 @@ func (c *Callbacks) SetDefaults() {
 		c.SaveRemoteConfigStatus = func(ctx context.Context, status *protobufs.RemoteConfigStatus) {}
 	}
 	if c.DownloadHTTPClient == nil {
-		defaultHttpClient := newHttpClient()
+		defaultHttpClient := utils.NewHttpClient()
 		c.DownloadHTTPClient = func(ctx context.Context, file *protobufs.DownloadableFile) (*http.Client, error) {
 			return defaultHttpClient, nil
 		}
 	}
-}
-
-func newHttpClient() *http.Client {
-	client := &http.Client{}
-	// Clone the default transport to avoid being affected by global state changes.
-	if tr, ok := http.DefaultTransport.(*http.Transport); ok {
-		tr = tr.Clone()
-		client.Transport = tr
-	}
-	return client
 }


### PR DESCRIPTION
DefaultHttpClient is a global variable and should not be modified concurrently.

We now clone it before modifying.

Resolves https://github.com/open-telemetry/opamp-go/issues/422