### PR TITLE
feat: WebSocket server send error callback

### DIFF
--- a/internal/wsmessage.go
+++ b/internal/wsmessage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/rand"
 
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
@@ -38,6 +39,11 @@ func DecodeWSMessage(bytes []byte, msg proto.Message) error {
 }
 
 func WriteWSMessage(conn *websocket.Conn, msg proto.Message) error {
+	// randomly fail to send 50% of the time
+	if rand.Intn(100) < 50 {
+		return fmt.Errorf("random failure")
+	}
+
 	data, err := proto.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("marshal message: %w", err)

--- a/internal/wsmessage.go
+++ b/internal/wsmessage.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/rand"
 
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
@@ -39,11 +38,6 @@ func DecodeWSMessage(bytes []byte, msg proto.Message) error {
 }
 
 func WriteWSMessage(conn *websocket.Conn, msg proto.Message) error {
-	// randomly fail to send 50% of the time
-	if rand.Intn(100) < 50 {
-		return fmt.Errorf("random failure")
-	}
-
 	data, err := proto.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("marshal message: %w", err)

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -232,8 +232,8 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 		defer func() {
 			err := wsConn.Close()
 			if err != nil {
-				if errors.Is(err, websocket.ErrCloseSent) {
-					s.logger.Debugf(context.Background(), "error closing the WebSocket connection - websocket already closed: %v", err)
+				if errors.Is(err, net.ErrClosed) {
+					s.logger.Debugf(context.Background(), "tried to close the WebSocket connection but it was already closed: %v", err)
 				} else {
 					s.logger.Errorf(context.Background(), "error closing the WebSocket connection: %v", err)
 				}
@@ -305,7 +305,7 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 		if err != nil {
 			// If we can read but not write to connection, we should break the loop to force a reconnect
 			s.logger.Errorf(msgContext, "Cannot send message to WebSocket: %v", err)
-			connectionCallbacks.OnSendMessageError(response, err)
+			connectionCallbacks.OnSendMessageError(agentConn, response, err)
 			break
 		}
 	}

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -225,7 +225,7 @@ func (s *server) httpHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Conn, connectionCallbacks *serverTypes.ConnectionCallbacks) {
-	agentConn := wsConnection{wsConn: wsConn, connMutex: &sync.Mutex{}, sendErrorCallback: connectionCallbacks.OnSendMessageError}
+	agentConn := wsConnection{wsConn: wsConn, connMutex: &sync.Mutex{}}
 
 	defer func() {
 		// Close the connection when all is done.
@@ -305,6 +305,7 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 		if err != nil {
 			// If we can read but not write to connection, we should break the loop to force a reconnect
 			s.logger.Errorf(msgContext, "Cannot send message to WebSocket: %v", err)
+			connectionCallbacks.OnSendMessageError(response, err)
 			break
 		}
 	}

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -232,7 +232,11 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 		defer func() {
 			err := wsConn.Close()
 			if err != nil {
-				s.logger.Errorf(context.Background(), "error closing the WebSocket connection: %v", err)
+				if errors.Is(err, websocket.ErrCloseSent) {
+					s.logger.Debugf(context.Background(), "error closing the WebSocket connection - websocket already closed: %v", err)
+				} else {
+					s.logger.Errorf(context.Background(), "error closing the WebSocket connection: %v", err)
+				}
 			}
 		}()
 
@@ -303,21 +307,6 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 			s.logger.Errorf(msgContext, "Cannot send message to WebSocket: %v", err)
 			break
 		}
-
-		// force nop after 30 seconds -- break loop after another 30 seconds
-		// switch {
-		// case time.Since(start) < 1*time.Minute:
-		// 	err = agentConn.Send(msgContext, response)
-		// 	if err != nil {
-		// 		s.logger.Errorf(msgContext, "Cannot send message to WebSocket: %v", err)
-		// 	}
-		// case time.Since(start) < 3*time.Minute:
-		// 	s.logger.Debugf(msgContext, "nop situation - no send")
-		// 	// nop situation -- do nothing
-		// case time.Since(start) < 4*time.Minute:
-		// 	// break loop; force reconnect
-		// 	break messageLoop
-		// }
 	}
 }
 

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -305,7 +305,7 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 		if err != nil {
 			// If we can read but not write to connection, we should break the loop to force a reconnect
 			s.logger.Errorf(msgContext, "Cannot send message to WebSocket: %v", err)
-			connectionCallbacks.OnSendMessageError(agentConn, response, err)
+			connectionCallbacks.OnMessageResponseError(agentConn, response, err)
 			break
 		}
 	}

--- a/server/types/callbacks.go
+++ b/server/types/callbacks.go
@@ -68,8 +68,8 @@ type ConnectionCallbacks struct {
 	// OnReadMessageError is called when an error occurs while reading or deserializing a message.
 	OnReadMessageError func(conn Connection, mt int, msgByte []byte, err error)
 
-	// OnSendMessageError is called when an error occurs while sending a message.
-	OnSendMessageError func(conn Connection, message *protobufs.ServerToAgent, err error)
+	// OnMessageResponseError is called when an error occurs while sending the response message from the OnMessage loop.
+	OnMessageResponseError func(conn Connection, message *protobufs.ServerToAgent, err error)
 }
 
 func defaultOnConnected(ctx context.Context, conn Connection) {}
@@ -106,7 +106,7 @@ func (c *ConnectionCallbacks) SetDefaults() {
 		c.OnReadMessageError = defaultOnReadMessageError
 	}
 
-	if c.OnSendMessageError == nil {
-		c.OnSendMessageError = defaultOnSendMessageError
+	if c.OnMessageResponseError == nil {
+		c.OnMessageResponseError = defaultOnSendMessageError
 	}
 }

--- a/server/types/callbacks.go
+++ b/server/types/callbacks.go
@@ -69,7 +69,7 @@ type ConnectionCallbacks struct {
 	OnReadMessageError func(conn Connection, mt int, msgByte []byte, err error)
 
 	// OnSendMessageError is called when an error occurs while sending a message.
-	OnSendMessageError func(message *protobufs.ServerToAgent, err error)
+	OnSendMessageError func(conn Connection, message *protobufs.ServerToAgent, err error)
 }
 
 func defaultOnConnected(ctx context.Context, conn Connection) {}
@@ -87,7 +87,7 @@ func defaultOnConnectionClose(conn Connection) {}
 
 func defaultOnReadMessageError(conn Connection, mt int, msgByte []byte, err error) {}
 
-func defaultOnSendMessageError(message *protobufs.ServerToAgent, err error) {}
+func defaultOnSendMessageError(conn Connection, message *protobufs.ServerToAgent, err error) {}
 
 func (c *ConnectionCallbacks) SetDefaults() {
 	if c.OnConnected == nil {

--- a/server/types/callbacks.go
+++ b/server/types/callbacks.go
@@ -67,6 +67,9 @@ type ConnectionCallbacks struct {
 
 	// OnReadMessageError is called when an error occurs while reading or deserializing a message.
 	OnReadMessageError func(conn Connection, mt int, msgByte []byte, err error)
+
+	// OnSendMessageError is called when an error occurs while sending a message.
+	OnSendMessageError func(message *protobufs.ServerToAgent, err error)
 }
 
 func defaultOnConnected(ctx context.Context, conn Connection) {}
@@ -84,6 +87,8 @@ func defaultOnConnectionClose(conn Connection) {}
 
 func defaultOnReadMessageError(conn Connection, mt int, msgByte []byte, err error) {}
 
+func defaultOnSendMessageError(message *protobufs.ServerToAgent, err error) {}
+
 func (c *ConnectionCallbacks) SetDefaults() {
 	if c.OnConnected == nil {
 		c.OnConnected = defaultOnConnected
@@ -99,5 +104,9 @@ func (c *ConnectionCallbacks) SetDefaults() {
 
 	if c.OnReadMessageError == nil {
 		c.OnReadMessageError = defaultOnReadMessageError
+	}
+
+	if c.OnSendMessageError == nil {
+		c.OnSendMessageError = defaultOnSendMessageError
 	}
 }

--- a/server/wsconnection.go
+++ b/server/wsconnection.go
@@ -17,9 +17,8 @@ type wsConnection struct {
 	// The websocket library does not allow multiple concurrent write operations,
 	// so ensure that we only have a single operation in progress at a time.
 	// For more: https://pkg.go.dev/github.com/gorilla/websocket#hdr-Concurrency
-	connMutex         *sync.Mutex
-	wsConn            *websocket.Conn
-	sendErrorCallback func(message *protobufs.ServerToAgent, err error)
+	connMutex *sync.Mutex
+	wsConn    *websocket.Conn
 }
 
 var _ types.Connection = (*wsConnection)(nil)
@@ -32,11 +31,7 @@ func (c wsConnection) Send(_ context.Context, message *protobufs.ServerToAgent) 
 	c.connMutex.Lock()
 	defer c.connMutex.Unlock()
 
-	err := internal.WriteWSMessage(c.wsConn, message)
-	if err != nil {
-		c.sendErrorCallback(message, err)
-	}
-	return err
+	return internal.WriteWSMessage(c.wsConn, message)
 }
 
 func (c wsConnection) Disconnect() error {


### PR DESCRIPTION
This PR adds functionality to the loop responsible for reading messages from the WebSocket connection to exit if we fail to send a message over the connection. This would trigger a reconnect from the client. Additionally it adds a new callback, OnMessageResponseError, that can be called in this event. This would follow behavior present when we fail to read from the connection.

Resolves https://github.com/open-telemetry/opamp-go/issues/426
