### PR TITLE
fix: Package Download race condition and close idle connections

### DIFF
--- a/client/internal/mocksender.go
+++ b/client/internal/mocksender.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"time"
+
+	"github.com/open-telemetry/opamp-go/client/types"
+)
+
+// MockSender is a mock implementation of the Sender interface for testing purposes.
+type MockSender struct {
+	nextMessage *NextMessage
+}
+
+// NewMockSender creates a new MockSender with default values.
+func NewMockSender() *MockSender {
+	nm := NewNextMessage()
+	return &MockSender{
+		nextMessage: &nm,
+	}
+}
+
+// NextMessage returns the next message to be sent.
+func (m *MockSender) NextMessage() *NextMessage {
+	return m.nextMessage
+}
+
+// ScheduleSend signals that a message is ready to be sent.
+func (m *MockSender) ScheduleSend() {}
+
+// SetInstanceUid sets the instance UID for subsequent messages.
+func (m *MockSender) SetInstanceUid(instanceUid types.InstanceUid) error {
+	return nil
+}
+
+// SetHeartbeatInterval sets the heartbeat interval.
+func (m *MockSender) SetHeartbeatInterval(duration time.Duration) error {
+	return nil
+}

--- a/client/internal/package_download_details_reporter.go
+++ b/client/internal/package_download_details_reporter.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -18,6 +19,7 @@ type downloadReporter struct {
 	downloaded atomic.Uint64
 
 	done chan struct{}
+	wg   sync.WaitGroup
 }
 
 func newDownloadReporter(interval time.Duration, length int) *downloadReporter {
@@ -29,6 +31,7 @@ func newDownloadReporter(interval time.Duration, length int) *downloadReporter {
 		interval:      interval,
 		packageLength: float64(length),
 		done:          make(chan struct{}),
+		wg:            sync.WaitGroup{},
 	}
 }
 
@@ -41,31 +44,36 @@ func (p *downloadReporter) Write(b []byte) (int, error) {
 
 // report periodically calls the passed function to with the download percent and rate to update the status of a package.
 func (p *downloadReporter) report(ctx context.Context, updateFn func(context.Context, protobufs.PackageDownloadDetails) error) {
-	ticker := time.NewTicker(p.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-p.done:
-			return
-		case <-ticker.C:
-			downloadTime := time.Since(p.start)
-			downloaded := float64(p.downloaded.Load())
-			bps := downloaded / float64(downloadTime/time.Second)
-			var downloadPercent float64
-			if p.packageLength > 0 {
-				downloadPercent = downloaded / p.packageLength * 100
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		ticker := time.NewTicker(p.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-p.done:
+				return
+			case <-ticker.C:
+				downloadTime := time.Since(p.start)
+				downloaded := float64(p.downloaded.Load())
+				bps := downloaded / float64(downloadTime/time.Second)
+				var downloadPercent float64
+				if p.packageLength > 0 {
+					downloadPercent = downloaded / p.packageLength * 100
+				}
+				_ = updateFn(ctx, protobufs.PackageDownloadDetails{
+					DownloadPercent:        downloadPercent,
+					DownloadBytesPerSecond: bps,
+				})
 			}
-			_ = updateFn(ctx, protobufs.PackageDownloadDetails{
-				DownloadPercent:        downloadPercent,
-				DownloadBytesPerSecond: bps,
-			})
 		}
-	}
+	}()
 }
 
 // stop the downloadReporter report goroutine
 func (p *downloadReporter) stop() {
 	close(p.done)
+	p.wg.Wait()
 }

--- a/client/internal/package_download_details_reporter_test.go
+++ b/client/internal/package_download_details_reporter_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ func Test_DownloadReporter_Report(t *testing.T) {
 		interval:      time.Millisecond,
 		packageLength: 2,
 		done:          make(chan struct{}),
+		wg:            sync.WaitGroup{},
 	}
 	defer reporter.stop()
 

--- a/client/internal/packagessyncer.go
+++ b/client/internal/packagessyncer.go
@@ -305,6 +305,7 @@ func (s *packagesSyncer) downloadFile(ctx context.Context, pkgName string, file 
 	if err != nil {
 		return fmt.Errorf("failed to create an HTTP Client to download file from %s: %v", file.DownloadUrl, err)
 	}
+	defer client.CloseIdleConnections()
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/client/internal/packagessyncer.go
+++ b/client/internal/packagessyncer.go
@@ -326,16 +326,8 @@ func (s *packagesSyncer) downloadFile(ctx context.Context, pkgName string, file 
 	}
 	// start the download reporter
 	detailsReporter := newDownloadReporter(s.reporterInterval, packageLength)
-	reportWG := sync.WaitGroup{}
-	reportWG.Add(1)
-	go func() {
-		detailsReporter.report(ctx, s.updateDownloadDetails(pkgName))
-		reportWG.Done()
-	}()
-	defer func() {
-		detailsReporter.stop()
-		reportWG.Wait()
-	}()
+	detailsReporter.report(ctx, s.updateDownloadDetails(pkgName))
+	defer detailsReporter.stop()
 
 	tr := io.TeeReader(resp.Body, detailsReporter)
 	err = s.localState.UpdateContent(ctx, pkgName, tr, file.ContentHash, file.Signature)

--- a/client/internal/packagessyncer_test.go
+++ b/client/internal/packagessyncer_test.go
@@ -2,13 +2,18 @@ package internal
 
 import (
 	"context"
+	"crypto/sha256"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opamp-go/client/types"
+	"github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPackagesSyncer(t *testing.T) {
@@ -50,4 +55,107 @@ func TestNewPackagesSyncer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPackageSyncerSync(t *testing.T) {
+	tests := []struct {
+		name                 string
+		testFileContent      []byte
+		getPackagesAvailable func(serverURL string, testFileContentHash []byte) *protobufs.PackagesAvailable
+		err                  string
+	}{
+		{
+			name:            "package available",
+			testFileContent: []byte("test package content for testing"),
+			getPackagesAvailable: func(serverURL string, testFileContentHash []byte) *protobufs.PackagesAvailable {
+				return &protobufs.PackagesAvailable{
+					Packages: map[string]*protobufs.PackageAvailable{
+						"": {
+							Type:    protobufs.PackageType_PackageType_TopLevel,
+							Version: "1.0.0",
+							Hash:    testFileContentHash[:],
+							File: &protobufs.DownloadableFile{
+								DownloadUrl: serverURL,
+								ContentHash: testFileContentHash[:],
+								Signature:   []byte{},
+							},
+						},
+					},
+					AllPackagesHash: testFileContentHash[:],
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test server
+			_, serverURL := createTestHTTPServer(t, tt.testFileContent)
+
+			// Setup packages available
+			testFileContentHash := sha256.Sum256(tt.testFileContent)
+			packagesAvailable := tt.getPackagesAvailable(serverURL, testFileContentHash[:])
+
+			// Setup packages store with initial state
+			store := NewInMemPackagesStore()
+			store.SetAllPackagesHash([]byte{})
+			store.SetPackageState("", types.PackageState{
+				Exists:  true,
+				Type:    protobufs.PackageType_PackageType_TopLevel,
+				Hash:    []byte{},
+				Version: "0.0.0",
+			})
+
+			s, err := NewPackagesSyncer(
+				&internal.NopLogger{},
+				packagesAvailable,
+				NewMockSender(),
+				&ClientSyncedState{},
+				store,
+				&sync.Mutex{},
+				time.Second,
+				func(context.Context, *protobufs.DownloadableFile) (*http.Client, error) {
+					return &http.Client{}, nil
+				},
+			)
+			require.NoError(t, err)
+
+			// Simulate Sync() so we can test the package installation without worrying about timing
+			s.mux.Lock()
+			err = s.initStatuses()
+			require.NoError(t, err)
+			err = s.clientSyncedState.SetPackageStatuses(s.statuses)
+			require.NoError(t, err)
+
+			// Run the sync operation
+			s.doSync(context.Background())
+
+			// Verify that the package is installed
+			packageState, err := store.PackageState("")
+			require.NoError(t, err)
+			assert.True(t, packageState.Exists)
+			assert.Equal(t, packageState.Type, protobufs.PackageType_PackageType_TopLevel)
+			assert.Equal(t, packageState.Hash, testFileContentHash[:])
+			assert.Equal(t, packageState.Version, "1.0.0")
+		})
+	}
+}
+
+// createTestHTTPServer creates a test HTTP server that serves the given file content
+// and returns the server and its URL. The server will be automatically closed
+// when the test completes.
+func createTestHTTPServer(t *testing.T, fileContent []byte) (*httptest.Server, string) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Write the file content
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(fileContent)
+		require.NoError(t, err)
+	}))
+
+	// Ensure the server is closed when the test completes
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	return server, server.URL
 }


### PR DESCRIPTION
Was running into a couple issues here while working on the supervisor to support upgrading the collector.

1. Data race
When syncing the package, we spin off a go routine to provide periodic updates on the progress. TLDR this go routine doesn't clean up by the time we update the package state with a successful install. This change adds a wait group so we make sure this routine exits before we continue.

2. Idle go routines
After resolving the data race, was also running into the following error. This was resolved by calling "CloseIdleConnections" on the http client we get to download the file. 

If you have any questions about these changes, let me know!

