### PR TITLE
Demo: Add initial-insecure-connection flag to example agent

### DIFF
--- a/internal/examples/agent/main.go
+++ b/internal/examples/agent/main.go
@@ -16,9 +16,12 @@ func main() {
 	var agentVersion string
 	flag.StringVar(&agentVersion, "v", "1.0.0", "Agent Version String")
 
+	var initialInsecureConnection bool
+	flag.BoolVar(&initialInsecureConnection, "initial-insecure-connection", false, "Set SkipInsecureVerify for the initial connection to the OpAMP server.")
+
 	flag.Parse()
 
-	agent := agent.NewAgent(&agent.Logger{log.Default()}, agentType, agentVersion)
+	agent := agent.NewAgent(&agent.Logger{log.Default()}, agentType, agentVersion, initialInsecureConnection)
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)


### PR DESCRIPTION
This is a POC to show that CA distribution as a part of offered TLS settings occurs automatically.
This can be used to distribute self-signed or internal CAs to clients that form the initial connection with `InsecureSkipVerify: true`.

- Relates: https://github.com/open-telemetry/opamp-spec/issues/257