### PR TITLE
Dockerfile for creating an image to test the opamp-server on localhost with supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
-# syntax=docker/dockerfile:1
 FROM golang:1.23 AS builder
 
 WORKDIR /src
-
-# Copy all source code
 COPY . /src
-
-# Build OpAMP server
 RUN cd internal/examples/server && go build -o /bin/opamp-server .
-
-# Build Supervisor
 RUN cd internal/examples/server && go build -o /bin/supervisor .
 
 COPY entrypoint.sh /entrypoint.sh
@@ -18,19 +11,10 @@ RUN chmod +x /entrypoint.sh
 # --------------------------------------------------
 
 FROM debian:bookworm-slim
-
 WORKDIR /app
-
-# Copy binaries
 COPY --from=builder /bin/opamp-server /bin/opamp-server
 COPY --from=builder /bin/supervisor /bin/supervisor
 COPY --from=builder /entrypoint.sh /entrypoint.sh
-
-# Copy UI templates
 COPY internal/examples/server/uisrv/html ./uisrv/html
-
-# Expose ports
 EXPOSE 4320 4321
-
-# Start both server and supervisor
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.23 AS builder
+
+WORKDIR /src
+
+# Copy all source code
+COPY . /src
+
+# Build OpAMP server
+RUN cd internal/examples/server && go build -o /bin/opamp-server .
+
+# Build Supervisor
+RUN cd internal/examples/server && go build -o /bin/supervisor .
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# --------------------------------------------------
+
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+# Copy binaries
+COPY --from=builder /bin/opamp-server /bin/opamp-server
+COPY --from=builder /bin/supervisor /bin/supervisor
+COPY --from=builder /entrypoint.sh /entrypoint.sh
+
+# Copy UI templates
+COPY internal/examples/server/uisrv/html ./uisrv/html
+
+# Expose ports
+EXPOSE 4320 4321
+
+# Start both server and supervisor
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+
+sleep 2
+
+/bin/supervisor --server-url ws://127.0.0.1:4320/v1/opamp &
+
+wait

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,6 @@
 
 
 sleep 2
-
 /bin/supervisor --server-url ws://127.0.0.1:4320/v1/opamp &
 
 wait


### PR DESCRIPTION
Issue: [https://github.com/open-telemetry/opamp-go/issues/443](https://github.com/open-telemetry/opamp-go/issues/443)

This PR adds a clean Docker-based setup for running the OpAMP server, its UI, and the Supervisor together for local testing and demos.

Changes included:

1. Added Dockerfile and entrypoint.sh to build and run both the OpAMP server and Supervisor in a single container.
2. Configured ports:
       - 4320 for the OpAMP server (protocol)
       - 4321 for the web UI

3. The entry point script ensures the Supervisor connects automatically to the local OpAMP server.

Please suggest changes or improvements if the solution is not as desired.