### PR TITLE
Use client.SetCapabilities() instead of deprecated Capabilities in the Agent example

### DIFF
--- a/internal/examples/agent/agent/agent.go
+++ b/internal/examples/agent/agent/agent.go
@@ -171,12 +171,6 @@ func (agent *Agent) connect(ops ...settingsOp) error {
 			OnConnectionSettings:      agent.onConnectionSettings,
 		},
 		RemoteConfigStatus: agent.remoteConfigStatus,
-		Capabilities: protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig |
-			protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig |
-			protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig |
-			protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnMetrics |
-			protobufs.AgentCapabilities_AgentCapabilities_AcceptsOpAMPConnectionSettings |
-			protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
 	}
 	for _, op := range ops {
 		op(&settings)
@@ -188,6 +182,17 @@ func (agent *Agent) connect(ops ...settingsOp) error {
 	}
 
 	err := agent.opampClient.SetAgentDescription(agent.agentDescription)
+	if err != nil {
+		return err
+	}
+
+	supportedCapabilities := protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig |
+		protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig |
+		protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig |
+		protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnMetrics |
+		protobufs.AgentCapabilities_AgentCapabilities_AcceptsOpAMPConnectionSettings |
+		protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus
+	err = agent.opampClient.SetCapabilities(&supportedCapabilities)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This minor PR, remove the deprecated message in the agent example log

```
2025/09/17 22:22:22 Starting OpAMP client...
2025/09/17 22:22:22 settings.Capabilities is deprecated, use client.SetCapabilities() instead
2025/09/17 22:22:22 OpAMP Client started.
```