### PR TITLE
Clone existing Transport before updating TLSConfig

### DIFF
--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -400,8 +400,13 @@ func (h *HTTPSender) EnableCompression() {
 
 func (h *HTTPSender) AddTLSConfig(config *tls.Config) {
 	if config != nil {
-		h.client.Transport = &http.Transport{
-			TLSClientConfig: config,
+		tlsTransport := &http.Transport{}
+		if h.client.Transport != nil {
+			if transport, ok := h.client.Transport.(*http.Transport); ok {
+				tlsTransport = transport.Clone()
+			}
 		}
+		tlsTransport.TLSClientConfig = config
+		h.client.Transport = tlsTransport
 	}
 }


### PR DESCRIPTION
Found this issue while doing some testing: When updating the TLS config, it will overwrite the existing client's Transport and all existing values are lost. We should instead clone the transport and only update the TLS config portion, similar to how SetProxy and NewHttpClient methods handle it.