### PR TITLE
[chore] Add repository check to tidy-dependencies workflow

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write # to allow pushing changes to the branch
     runs-on: ubuntu-latest
-    if: ${{ (github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'renovatebot')) }}
+    if: ${{ (github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'renovatebot')) && github.event.pull_request.head.repo.fork == false }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v5


### PR DESCRIPTION
Add a repository origin check to the `tidy.yml` workflow (with write permissions) to ensure it can't be triggered by PRs from forks.

Same as https://github.com/open-telemetry/opentelemetry-collector/pull/14344