### PR TITLE
Server uses sync.Pool for gzip.Writer allocations

### DIFF
--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -362,20 +362,6 @@ func (s *server) compressGzip(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func compressGzip(data []byte) ([]byte, error) {
-	var buf bytes.Buffer
-	w := gzip.NewWriter(&buf)
-	_, err := w.Write(data)
-	if err != nil {
-		return nil, err
-	}
-	err = w.Close()
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
 func (s *server) handlePlainHTTPRequest(req *http.Request, w http.ResponseWriter, connectionCallbacks *serverTypes.ConnectionCallbacks) {
 	bodyBytes, err := s.readReqBody(req)
 	if err != nil {

--- a/server/serverimpl_test.go
+++ b/server/serverimpl_test.go
@@ -1413,13 +1413,4 @@ func BenchmarkCompressGzip(b *testing.B) {
 			}
 		}
 	})
-
-	b.Run("no pool", func(b *testing.B) {
-		for range b.N {
-			p, err := compressGzip(input)
-			if p == nil || err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
 }


### PR DESCRIPTION
Use of gzip.Writer pool for plain HTTP responses - gzip.Writers have a large memory footprint, if many agent clients clients were to respond at once a server could have an OOM crash. Use of the pool also reduces allocs.

```
go test -v -benchmem -benchtime 5s -bench=BenchmarkCompressGzip
...
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opamp-go/server
cpu: Apple M3 Pro
BenchmarkCompressGzip
BenchmarkCompressGzip/with_pool
BenchmarkCompressGzip/with_pool-12         	  483432	     12155 ns/op	     113 B/op	       2 allocs/op
BenchmarkCompressGzip/no_pool
BenchmarkCompressGzip/no_pool-12           	   96456	     60972 ns/op	  813988 B/op	      19 allocs/op
```