### PR TITLE
fix: create SetConnectionSettingsStatus method

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -74,6 +74,12 @@ type OpAMPClient interface {
 	// nil values are not allowed and will return an error.
 	SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error
 
+	// SetConnectionSettingsStatus sets the current ConnectionSettingsStatus.
+	// LastConnectionSettingsHash field must be non-nil.
+	// May be called anytime after Start(), including from OnMessage handler.
+	// nil values are not allowed and will return an error.
+	SetConnectionSettingsStatus(status *protobufs.ConnectionSettingsStatus) error
+
 	// SetPackageStatuses sets the current PackageStatuses.
 	// ServerProvidedAllPackagesHash must be non-nil.
 	// May be called anytime after Start(), including from OnMessage handler.

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -108,6 +108,11 @@ func (c *httpClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus)
 	return c.common.SetRemoteConfigStatus(status)
 }
 
+// SetConnectionSettingsStatus implements OpAMPClient.SetConnectionSettingsStatus.
+func (c *httpClient) SetConnectionSettingsStatus(status *protobufs.ConnectionSettingsStatus) error {
+	return c.common.SetConnectionSettingsStatus(status)
+}
+
 // SetPackageStatuses implements OpAMPClient.SetPackageStatuses.
 func (c *httpClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
 	return c.common.SetPackageStatuses(statuses)

--- a/client/internal/clientstate.go
+++ b/client/internal/clientstate.go
@@ -11,6 +11,7 @@ import (
 var (
 	errRemoteConfigStatusMissing        = errors.New("RemoteConfigStatus is not set")
 	errLastRemoteConfigHashNil          = errors.New("LastRemoteConfigHash is nil")
+	errLastConnectionSettingsHashNil    = errors.New("LastConnectionSettingsHash is nil")
 	errConnectionSettingsStatusMissing  = errors.New("ConnectionSettingsStatus is not set")
 	errPackageStatusesMissing           = errors.New("PackageStatuses is not set")
 	errServerProvidedAllPackagesHashNil = errors.New("ServerProvidedAllPackagesHash is nil")

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -160,6 +160,10 @@ func (c *wsClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) e
 	return c.common.SetRemoteConfigStatus(status)
 }
 
+func (c *wsClient) SetConnectionSettingsStatus(status *protobufs.ConnectionSettingsStatus) error {
+	return c.common.SetConnectionSettingsStatus(status)
+}
+
 func (c *wsClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
 	return c.common.SetPackageStatuses(statuses)
 }


### PR DESCRIPTION
## Goal

This PR implements a new function for the client `SetConnectionSettingsStatus`. It is implemented following the footsteps of the remote config status one for better readability and maintenance.
This PR only introduces the implementations that relies on existing components like client state.

This PR is part of this [issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46157) to let the opamp server know how went a settings offer (similarly than for remote config)

## Tests
I did not add unit tests to the code i have written because i did not see any tests for `SetRemoteConfigStatus`. Let me know if it is needed and will implement them

## Documentation
All new functions have docstrings. No additional documentation was made. Let me know if thats a problem

## linked issues

- open-telemetry/opentelemetry-collector-contrib#46157

> I am a new contributor and wanted to give back to this great initiative. I am sorry in advance if i missed a rule

