### PR TITLE
Allow connection settings to be applied asynchronously

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -89,6 +89,14 @@ type OpAMPClient interface {
 	// May be also called from OnMessage handler.
 	RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error
 
+	// SetConnectionSettingsStatus sets the current ConnectionSettingsStatus.
+	// LastConnectionSettingsHash field must be non-nil.
+	// May be called anytime after Start(), including from OnMessage handler.
+	// nil values are not allowed and will return an error.
+	// Must be explicitly used after OnOpampConnectionSettings/OnConnectionSettings
+	// has completed with APPLIED or FAILED.
+	SetConnectionSettingsStatus(status *protobufs.ConnectionSettingsStatus) error
+
 	// SetCustomCapabilities modifies the set of customCapabilities supported by the client.
 	// The new customCapabilities will be sent with the next message to the server. If
 	// custom capabilities are used SHOULD be called before Start(). If not called before

--- a/client/client.go
+++ b/client/client.go
@@ -90,11 +90,12 @@ type OpAMPClient interface {
 	RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error
 
 	// SetConnectionSettingsStatus sets the current ConnectionSettingsStatus.
-	// LastConnectionSettingsHash field must be non-nil.
+	// LastConnectionSettingsHash field must be non-empty.
 	// May be called anytime after Start(), including from OnMessage handler.
 	// nil values are not allowed and will return an error.
-	// Must be explicitly used after OnOpampConnectionSettings/OnConnectionSettings
-	// has completed with APPLIED or FAILED.
+	// Must be explicitly used to report APPLIED or FAILED after
+	// OnOpampConnectionSettings/OnConnectionSettings completes, including
+	// asynchronously after the callback returns.
 	SetConnectionSettingsStatus(status *protobufs.ConnectionSettingsStatus) error
 
 	// SetCustomCapabilities modifies the set of customCapabilities supported by the client.

--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -2757,3 +2757,171 @@ func generateTestAvailableComponents() *protobufs.AvailableComponents {
 		},
 	}
 }
+
+func TestSetConnectionSettingsStatus(t *testing.T) {
+	testCases := []struct {
+		name         string
+		capabilities protobufs.AgentCapabilities
+		needsServer  bool
+		testFunc     func(t *testing.T, client OpAMPClient, srv *internal.MockServer)
+	}{{
+		name:         "no capability returns error",
+		capabilities: coreCapabilities,
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer) {
+			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+				LastConnectionSettingsHash: []byte{1, 2, 3},
+				Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
+			})
+			require.ErrorIs(t, err, internal.ErrReportsConnectionSettingsStatusNotSet)
+		},
+	}, {
+		name:         "nil hash returns error",
+		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer) {
+			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+				Status: protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
+			})
+			require.Error(t, err)
+		},
+	}, {
+		name:         "sends status to server",
+		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
+		needsServer:  true,
+		testFunc: func(t *testing.T, client OpAMPClient, srv *internal.MockServer) {
+			gotApplied := new(atomic.Bool)
+			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				if msg.ConnectionSettingsStatus != nil &&
+					msg.ConnectionSettingsStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED {
+					gotApplied.Store(true)
+				}
+				return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
+			}
+
+			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+				LastConnectionSettingsHash: []byte{1, 2, 3},
+				Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
+			})
+			require.NoError(t, err)
+			eventually(t, func() bool { return gotApplied.Load() })
+		},
+	}, {
+		name:         "duplicate status is no-op",
+		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
+		needsServer:  true,
+		testFunc: func(t *testing.T, client OpAMPClient, srv *internal.MockServer) {
+			var appliedCount atomic.Int64
+			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				if msg.ConnectionSettingsStatus != nil &&
+					msg.ConnectionSettingsStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED {
+					appliedCount.Add(1)
+				}
+				return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
+			}
+
+			status := &protobufs.ConnectionSettingsStatus{
+				LastConnectionSettingsHash: []byte{1, 2, 3},
+				Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
+			}
+
+			// First call should send to server.
+			err := client.SetConnectionSettingsStatus(status)
+			require.NoError(t, err)
+			eventually(t, func() bool { return appliedCount.Load() == 1 })
+
+			// Second call with identical status should be a no-op (updateStoredConnectionSettingsStatus returns false).
+			err = client.SetConnectionSettingsStatus(status)
+			require.NoError(t, err)
+
+			eventually(t, func() bool { return appliedCount.Load() == 1 })
+		},
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testClients(t, func(t *testing.T, client OpAMPClient) {
+				var srv *internal.MockServer
+				var settings types.StartSettings
+
+				if tc.needsServer {
+					srv = internal.StartMockServer(t)
+					defer srv.Close()
+					settings.OpAMPServerURL = "ws://" + srv.Endpoint
+				} else {
+					settings = createNoServerSettings()
+				}
+				settings.Capabilities = tc.capabilities
+
+				startClient(t, settings, client)
+				tc.testFunc(t, client, srv)
+
+				err := client.Stop(t.Context())
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
+// TestSetConnectionSettingsStatusAsync tests that when the server offers connection settings,
+// the client sets APPLYING automatically, and then the agent can asynchronously set APPLIED via
+// SetConnectionSettingsStatus.
+func TestSetConnectionSettingsStatusAsync(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		hash := []byte{1, 2, 3}
+		gotApplying := new(atomic.Bool)
+		gotApplied := new(atomic.Bool)
+		callbackCalled := new(atomic.Bool)
+
+		srv := internal.StartMockServer(t)
+		defer srv.Close()
+
+		firstMessage := true
+		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			if msg.ConnectionSettingsStatus != nil {
+				switch msg.ConnectionSettingsStatus.Status {
+				case protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLYING:
+					gotApplying.Store(true)
+				case protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED:
+					gotApplied.Store(true)
+				}
+			}
+			resp := &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
+			if firstMessage {
+				firstMessage = false
+				resp.ConnectionSettings = &protobufs.ConnectionSettingsOffers{
+					Hash:  hash,
+					Opamp: &protobufs.OpAMPConnectionSettings{DestinationEndpoint: "http://opamp.com"},
+				}
+			}
+			return resp
+		}
+
+		capabilities := coreCapabilities |
+			protobufs.AgentCapabilities_AgentCapabilities_AcceptsOpAMPConnectionSettings |
+			protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus
+		settings := types.StartSettings{
+			Capabilities:   capabilities,
+			OpAMPServerURL: "ws://" + srv.Endpoint,
+			Callbacks: types.Callbacks{
+				OnOpampConnectionSettings: func(ctx context.Context, settings *protobufs.OpAMPConnectionSettings) error {
+					callbackCalled.Store(true)
+					return nil
+				},
+			},
+		}
+		startClient(t, settings, client)
+
+		eventually(t, func() bool { return gotApplying.Load() })
+		eventually(t, func() bool { return callbackCalled.Load() })
+
+		err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+			LastConnectionSettingsHash: hash,
+			Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
+		})
+		require.NoError(t, err)
+
+		eventually(t, func() bool { return gotApplied.Load() })
+
+		err = client.Stop(t.Context())
+		require.NoError(t, err)
+	})
+}

--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -2775,6 +2775,13 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 			require.ErrorIs(t, err, internal.ErrReportsConnectionSettingsStatusNotSet)
 		},
 	}, {
+		name:         "nil status returns error",
+		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer) {
+			err := client.SetConnectionSettingsStatus(nil)
+			require.Error(t, err)
+		},
+	}, {
 		name:         "nil hash returns error",
 		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
 		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer) {

--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -2841,6 +2841,58 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 
 			eventually(t, func() bool { return appliedCount.Load() == 1 })
 		},
+	}, {
+		name:         "sends FAILED status to server",
+		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
+		needsServer:  true,
+		testFunc: func(t *testing.T, client OpAMPClient, srv *internal.MockServer) {
+			gotFailed := new(atomic.Bool)
+			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				if msg.ConnectionSettingsStatus != nil &&
+					msg.ConnectionSettingsStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED {
+					gotFailed.Store(true)
+				}
+				return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
+			}
+
+			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+				LastConnectionSettingsHash: []byte{1, 2, 3},
+				Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED,
+				ErrorMessage:               "TLS verification failed",
+			})
+			require.NoError(t, err)
+			eventually(t, func() bool { return gotFailed.Load() })
+		},
+	}, {
+		name:         "different hash triggers send",
+		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
+		needsServer:  true,
+		testFunc: func(t *testing.T, client OpAMPClient, srv *internal.MockServer) {
+			var appliedCount atomic.Int64
+			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				if msg.ConnectionSettingsStatus != nil &&
+					msg.ConnectionSettingsStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED {
+					appliedCount.Add(1)
+				}
+				return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
+			}
+
+			// First call with hash A.
+			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+				LastConnectionSettingsHash: []byte{1, 2, 3},
+				Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
+			})
+			require.NoError(t, err)
+			eventually(t, func() bool { return appliedCount.Load() == 1 })
+
+			// Second call with different hash B should still send.
+			err = client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+				LastConnectionSettingsHash: []byte{4, 5, 6},
+				Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
+			})
+			require.NoError(t, err)
+			eventually(t, func() bool { return appliedCount.Load() == 2 })
+		},
 	}}
 
 	for _, tc := range testCases {

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -108,6 +108,11 @@ func (c *httpClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus)
 	return c.common.SetRemoteConfigStatus(status)
 }
 
+// SetConnectionSettingsStatus implements OpAMPClient.SetConnectionSettingsStatus.
+func (c *httpClient) SetConnectionSettingsStatus(status *protobufs.ConnectionSettingsStatus) error {
+	return c.common.SetConnectionSettingsStatus(status)
+}
+
 // SetPackageStatuses implements OpAMPClient.SetPackageStatuses.
 func (c *httpClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
 	return c.common.SetPackageStatuses(statuses)

--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -331,6 +331,10 @@ func (c *ClientCommon) SetConnectionSettingsStatus(status *protobufs.ConnectionS
 		return ErrReportsConnectionSettingsStatusNotSet
 	}
 
+	if status == nil {
+		return errConnectionSettingsStatusMissing
+	}
+
 	if len(status.LastConnectionSettingsHash) == 0 {
 		return errLastConnectionSettingsHashEmpty
 	}

--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -14,19 +14,21 @@ import (
 )
 
 var (
-	ErrAgentDescriptionMissing      = errors.New("AgentDescription is nil")
-	ErrAgentDescriptionNoAttributes = errors.New("AgentDescription has no attributes defined")
-	ErrHealthMissing                = errors.New("health is nil")
-	ErrReportsEffectiveConfigNotSet = errors.New("ReportsEffectiveConfig capability is not set")
-	ErrReportsRemoteConfigNotSet    = errors.New("ReportsRemoteConfig capability is not set")
-	ErrPackagesStateProviderNotSet  = errors.New("PackagesStateProvider must be set")
-	ErrCapabilitiesNotSet           = errors.New("Capabilities is not set")
-	ErrAcceptsPackagesNotSet        = errors.New("AcceptsPackages and ReportsPackageStatuses must be set")
-	ErrAvailableComponentsMissing   = errors.New("AvailableComponents is nil")
+	ErrAgentDescriptionMissing               = errors.New("AgentDescription is nil")
+	ErrAgentDescriptionNoAttributes          = errors.New("AgentDescription has no attributes defined")
+	ErrHealthMissing                         = errors.New("health is nil")
+	ErrReportsEffectiveConfigNotSet          = errors.New("ReportsEffectiveConfig capability is not set")
+	ErrReportsRemoteConfigNotSet             = errors.New("ReportsRemoteConfig capability is not set")
+	ErrPackagesStateProviderNotSet           = errors.New("PackagesStateProvider must be set")
+	ErrCapabilitiesNotSet                    = errors.New("Capabilities is not set")
+	ErrAcceptsPackagesNotSet                 = errors.New("AcceptsPackages and ReportsPackageStatuses must be set")
+	ErrAvailableComponentsMissing            = errors.New("AvailableComponents is nil")
+	ErrReportsConnectionSettingsStatusNotSet = errors.New("ReportsConnectionSettingsStatus capability is not set")
 
-	errAlreadyStarted               = errors.New("already started")
-	errCannotStopNotStarted         = errors.New("cannot stop because not started")
-	errReportsPackageStatusesNotSet = errors.New("ReportsPackageStatuses capability is not set")
+	errAlreadyStarted                  = errors.New("already started")
+	errCannotStopNotStarted            = errors.New("cannot stop because not started")
+	errReportsPackageStatusesNotSet    = errors.New("ReportsPackageStatuses capability is not set")
+	errLastConnectionSettingsHashEmpty = errors.New("LastConnectionSettingsHash is empty")
 )
 
 // ClientCommon contains the OpAMP logic that is common between WebSocket and
@@ -318,6 +320,35 @@ func (c *ClientCommon) RequestConnectionSettings(request *protobufs.ConnectionSe
 		},
 	)
 	c.sender.ScheduleSend()
+	return nil
+}
+
+// SetConnectionSettingsStatus sends a status update to the Server with the new ConnectionSettingsStatus.
+// It also remembers the new status in the client state so that it can be sent
+// to the Server when the Server asks for it.
+func (c *ClientCommon) SetConnectionSettingsStatus(status *protobufs.ConnectionSettingsStatus) error {
+	if !c.hasCapability(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus) {
+		return ErrReportsConnectionSettingsStatusNotSet
+	}
+
+	if len(status.LastConnectionSettingsHash) == 0 {
+		return errLastConnectionSettingsHashEmpty
+	}
+
+	oldStatus := c.ClientSyncedState.ConnectionSettingsStatus()
+	if !updateStoredConnectionSettingsStatus(oldStatus, status) {
+		return nil
+	}
+
+	if err := c.ClientSyncedState.SetConnectionSettingsStatus(status); err != nil {
+		return err
+	}
+
+	c.sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
+		msg.ConnectionSettingsStatus = c.ClientSyncedState.ConnectionSettingsStatus()
+	})
+	c.sender.ScheduleSend()
+
 	return nil
 }
 

--- a/client/internal/clientstate.go
+++ b/client/internal/clientstate.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"errors"
 	"sync"
 
@@ -246,4 +247,17 @@ func (s *ClientSyncedState) SetCapabilities(capabilities *protobufs.AgentCapabil
 	s.agentCapabilities = *capabilities
 
 	return nil
+}
+
+// updateStoredConnectionSettingsStatus returns true if status should replace oldStatus.
+// It's true if:
+// - no oldStatus
+// - hash changes
+// - status changes from APPLYING or UNSET
+// - status changes to FAILED
+func updateStoredConnectionSettingsStatus(oldStatus, status *protobufs.ConnectionSettingsStatus) bool {
+	return oldStatus == nil || !bytes.Equal(oldStatus.LastConnectionSettingsHash, status.LastConnectionSettingsHash) ||
+		oldStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLYING ||
+		oldStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_UNSET ||
+		status.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED
 }

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -345,17 +344,4 @@ func (r *receivedProcessor) rcvCommand(ctx context.Context, command *protobufs.S
 	if command != nil {
 		r.callbacks.OnCommand(ctx, command)
 	}
-}
-
-// updateStoredConnectionSettingsStatus returns a bool of if status should replace oldStatus.
-// It's true if:
-// - no oldStatus
-// - hash changes
-// - status changes from APPLYING or UNSET
-// - status changes to FAILED
-func updateStoredConnectionSettingsStatus(oldStatus, status *protobufs.ConnectionSettingsStatus) bool {
-	return oldStatus == nil || !bytes.Equal(oldStatus.LastConnectionSettingsHash, status.LastConnectionSettingsHash) ||
-		oldStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLYING ||
-		oldStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_UNSET ||
-		status.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED
 }

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -275,34 +275,6 @@ func (r *receivedProcessor) rcvOpampConnectionSettings(ctx context.Context, sett
 		if err != nil {
 			r.logger.Errorf(ctx, "Failed to process OpAMPConnectionSettings: %v", err)
 		}
-		if r.hasCapability(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus) {
-			status := protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED
-			errMsg := ""
-			if err != nil {
-				status = protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED
-				errMsg = err.Error()
-			}
-
-			connectionStatus := &protobufs.ConnectionSettingsStatus{
-				LastConnectionSettingsHash: settings.Hash,
-				Status:                     status,
-				ErrorMessage:               errMsg,
-			}
-			oldStatus := r.clientSyncedState.ConnectionSettingsStatus()
-
-			if !updateStoredConnectionSettingsStatus(oldStatus, connectionStatus) {
-				r.logger.Debugf(ctx, "Client skipping connection status state update from %v to %v", oldStatus.GetStatus(), connectionStatus.GetStatus())
-				return
-			}
-
-			if err := r.clientSyncedState.SetConnectionSettingsStatus(connectionStatus); err != nil {
-				r.logger.Errorf(ctx, "Unable to persist connection settings status %s state: %v", status.String(), err)
-			}
-			r.sender.NextMessage().Update(func(sendMsg *protobufs.AgentToServer) {
-				sendMsg.ConnectionSettingsStatus = connectionStatus
-			})
-			r.sender.ScheduleSend()
-		}
 	} else {
 		r.logger.Debugf(ctx, "Ignoring Opamp, agent does not have AcceptsOpAMPConnectionSettings capability")
 	}
@@ -338,34 +310,6 @@ func (r *receivedProcessor) rcvConnectionSettings(ctx context.Context, settings 
 		err := r.callbacks.OnConnectionSettings(ctx, settings)
 		if err != nil {
 			r.logger.Errorf(ctx, "Failed to process ConnectionSettings: %v", err)
-		}
-		if r.hasCapability(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus) {
-			status := protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED
-			errMsg := ""
-			if err != nil {
-				status = protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED
-				errMsg = err.Error()
-			}
-
-			connectionStatus := &protobufs.ConnectionSettingsStatus{
-				LastConnectionSettingsHash: settings.Hash,
-				Status:                     status,
-				ErrorMessage:               errMsg,
-			}
-			oldStatus := r.clientSyncedState.ConnectionSettingsStatus()
-
-			if !updateStoredConnectionSettingsStatus(oldStatus, connectionStatus) {
-				r.logger.Debugf(ctx, "Client skipping connection status state update from %v to %v", oldStatus.GetStatus(), connectionStatus.GetStatus())
-				return
-			}
-
-			if err := r.clientSyncedState.SetConnectionSettingsStatus(connectionStatus); err != nil {
-				r.logger.Errorf(ctx, "Unable to persist connection settings status %s state: %v", status.String(), err)
-			}
-			r.sender.NextMessage().Update(func(sendMsg *protobufs.AgentToServer) {
-				sendMsg.ConnectionSettingsStatus = connectionStatus
-			})
-			r.sender.ScheduleSend()
 		}
 	} else {
 		r.logger.Debugf(ctx, "Ignoring ConnectionSettings, agent does not have corresponding capability")

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -273,6 +273,11 @@ func (r *receivedProcessor) rcvOpampConnectionSettings(ctx context.Context, sett
 		err := r.callbacks.OnOpampConnectionSettings(ctx, settings.Opamp)
 		if err != nil {
 			r.logger.Errorf(ctx, "Failed to process OpAMPConnectionSettings: %v", err)
+			r.clientSyncedState.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+				LastConnectionSettingsHash: settings.Hash,
+				Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED,
+				ErrorMessage:               "failed to process OpAMP connection settings",
+			})
 		}
 	} else {
 		r.logger.Debugf(ctx, "Ignoring Opamp, agent does not have AcceptsOpAMPConnectionSettings capability")

--- a/client/types/callbacks.go
+++ b/client/types/callbacks.go
@@ -92,7 +92,11 @@ type Callbacks struct {
 	//
 	// The Agent should process the offer by reconnecting the client using the new
 	// settings or return an error if the Agent does not want to accept the settings
-	// (e.g. if the TSL certificate in the settings cannot be verified).
+	// (e.g. if the TLS certificate in the settings cannot be verified).
+	//
+	// The caller is responsible for reporting the outcome via
+	// OpAMPClient.SetConnectionSettingsStatus with APPLIED or FAILED status.
+	// The client automatically sets APPLYING when the offer is received.
 	//
 	// Only one OnOpampConnectionSettings call can be active at any time.
 	// See OnRemoteConfig for the behavior.
@@ -138,12 +142,16 @@ type Callbacks struct {
 	// The callback must return a non-nil HTTP client or an error.
 	DownloadHTTPClient func(ctx context.Context, file *protobufs.DownloadableFile) (*http.Client, error)
 
-	// OnConnectionSettings is called when the agent recieves any non OpAMP
+	// OnConnectionSettings is called when the agent receives any non-OpAMP
 	// connection settings.
 	//
-	// The Agent should process the offer by reconnecting the client using the new
-	// settings or return an error if the Agent does not want to accept the settings
-	// (e.g. if the TSL certificate in the settings cannot be verified).
+	// The Agent should process the offer by applying the new settings or return
+	// an error if the Agent does not want to accept the settings (e.g. if the
+	// TLS certificate in the settings cannot be verified).
+	//
+	// The caller is responsible for reporting the outcome via
+	// OpAMPClient.SetConnectionSettingsStatus with APPLIED or FAILED status.
+	// The client automatically sets APPLYING when the offer is received.
 	//
 	// Only one OnConnectionSettings call can be active at any time.
 	// See OnRemoteConfig for the behavior.

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -161,6 +161,9 @@ func (c *wsClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) e
 	return c.common.SetRemoteConfigStatus(status)
 }
 
+// SetConnectionSettingsStatus sets the current ConnectionSettingsStatus and sends
+// it to the Server. Must be called after processing connection settings offers to
+// report APPLIED or FAILED status.
 func (c *wsClient) SetConnectionSettingsStatus(status *protobufs.ConnectionSettingsStatus) error {
 	return c.common.SetConnectionSettingsStatus(status)
 }

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -161,6 +161,10 @@ func (c *wsClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) e
 	return c.common.SetRemoteConfigStatus(status)
 }
 
+func (c *wsClient) SetConnectionSettingsStatus(status *protobufs.ConnectionSettingsStatus) error {
+	return c.common.SetConnectionSettingsStatus(status)
+}
+
 func (c *wsClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
 	return c.common.SetPackageStatuses(statuses)
 }

--- a/internal/examples/agent/agent/agent.go
+++ b/internal/examples/agent/agent/agent.go
@@ -682,11 +682,13 @@ func (agent *Agent) tryChangeOpAMP(ctx context.Context, cert *tls.Certificate, t
 
 	if err := agent.connect(withTLSConfig(tlsConfig), withProxy(proxy)); err != nil {
 		agent.logger.Errorf(ctx, "Cannot connect after using new tls config: %s. Ignoring the offer\n", err)
-		agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+		if statusErr := agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
 			LastConnectionSettingsHash: hash,
 			Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED,
 			ErrorMessage:               err.Error(),
-		})
+		}); statusErr != nil {
+			agent.logger.Errorf(ctx, "Failed to report connection settings status: %v", statusErr)
+		}
 		if err := agent.connect(withTLSConfig(oldCfg), withProxy(oldProxy)); err != nil {
 			agent.logger.Errorf(ctx, "Unable to reconnect after restoring tls config: %s\n", err)
 		}
@@ -694,10 +696,12 @@ func (agent *Agent) tryChangeOpAMP(ctx context.Context, cert *tls.Certificate, t
 	}
 
 	agent.logger.Debugf(ctx, "Successfully connected to server. Accepting new tls config.\n")
-	agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+	if statusErr := agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
 		LastConnectionSettingsHash: hash,
 		Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
-	})
+	}); statusErr != nil {
+		agent.logger.Errorf(ctx, "Failed to report connection settings status: %v", statusErr)
+	}
 	// TODO: we can also persist the successfully accepted settigns and use it when the
 	// agent connects to the server after the restart.
 }
@@ -761,7 +765,9 @@ func (agent *Agent) onOpampConnectionSettings(ctx context.Context, settings *pro
 		}
 	}
 	// TODO: also use settings.DestinationEndpoint and settings.Headers for future connections.
-	go agent.tryChangeOpAMP(ctx, cert, tlsConfig, proxy, agent.lastConnectionSettingsHash)
+	hash := make([]byte, len(agent.lastConnectionSettingsHash))
+	copy(hash, agent.lastConnectionSettingsHash)
+	go agent.tryChangeOpAMP(ctx, cert, tlsConfig, proxy, hash)
 
 	return nil
 }
@@ -852,11 +858,13 @@ func (agent *Agent) onConnectionSettings(ctx context.Context, settings *protobuf
 			status = protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED
 			errMsg = err.Error()
 		}
-		agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+		if statusErr := agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
 			LastConnectionSettingsHash: settings.Hash,
 			Status:                     status,
 			ErrorMessage:               errMsg,
-		})
+		}); statusErr != nil {
+			agent.logger.Errorf(context.Background(), "Failed to report connection settings status: %v", statusErr)
+		}
 		return err
 	}
 	return nil

--- a/internal/examples/agent/agent/agent.go
+++ b/internal/examples/agent/agent/agent.go
@@ -83,6 +83,10 @@ type Agent struct {
 
 	certRequested       bool
 	clientPrivateKeyPEM []byte
+
+	// lastConnectionSettingsHash stores the hash of the most recently received
+	// ConnectionSettingsOffers, used when reporting connection settings status.
+	lastConnectionSettingsHash []byte
 }
 
 type proxySettings struct {
@@ -553,6 +557,10 @@ func (agent *Agent) requestClientCertificate() {
 }
 
 func (agent *Agent) onMessage(ctx context.Context, msg *types.MessageData) {
+	if msg.OfferedConnectionsSettingsHash != nil {
+		agent.lastConnectionSettingsHash = msg.OfferedConnectionsSettingsHash
+	}
+
 	configChanged := false
 	if msg.RemoteConfig != nil {
 		var err error
@@ -650,7 +658,7 @@ func (agent *Agent) sendCustomMessage(ctx context.Context, message *protobufs.Cu
 	}
 }
 
-func (agent *Agent) tryChangeOpAMP(ctx context.Context, cert *tls.Certificate, tlsConfig *tls.Config, proxy *proxySettings) {
+func (agent *Agent) tryChangeOpAMP(ctx context.Context, cert *tls.Certificate, tlsConfig *tls.Config, proxy *proxySettings, hash []byte) {
 	agent.logger.Debugf(ctx, "Reconnecting to verify new OpAMP settings.\n")
 	agent.disconnect(ctx)
 
@@ -674,6 +682,11 @@ func (agent *Agent) tryChangeOpAMP(ctx context.Context, cert *tls.Certificate, t
 
 	if err := agent.connect(withTLSConfig(tlsConfig), withProxy(proxy)); err != nil {
 		agent.logger.Errorf(ctx, "Cannot connect after using new tls config: %s. Ignoring the offer\n", err)
+		agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+			LastConnectionSettingsHash: hash,
+			Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED,
+			ErrorMessage:               err.Error(),
+		})
 		if err := agent.connect(withTLSConfig(oldCfg), withProxy(oldProxy)); err != nil {
 			agent.logger.Errorf(ctx, "Unable to reconnect after restoring tls config: %s\n", err)
 		}
@@ -681,6 +694,10 @@ func (agent *Agent) tryChangeOpAMP(ctx context.Context, cert *tls.Certificate, t
 	}
 
 	agent.logger.Debugf(ctx, "Successfully connected to server. Accepting new tls config.\n")
+	agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+		LastConnectionSettingsHash: hash,
+		Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
+	})
 	// TODO: we can also persist the successfully accepted settigns and use it when the
 	// agent connects to the server after the restart.
 }
@@ -744,7 +761,7 @@ func (agent *Agent) onOpampConnectionSettings(ctx context.Context, settings *pro
 		}
 	}
 	// TODO: also use settings.DestinationEndpoint and settings.Headers for future connections.
-	go agent.tryChangeOpAMP(ctx, cert, tlsConfig, proxy)
+	go agent.tryChangeOpAMP(ctx, cert, tlsConfig, proxy, agent.lastConnectionSettingsHash)
 
 	return nil
 }
@@ -828,7 +845,19 @@ func (agent *Agent) onConnectionSettings(ctx context.Context, settings *protobuf
 	agent.logger.Debugf(context.Background(), "Received connection settings offers from server, hash=%x.", settings.Hash)
 	// TODO handle traces, logs, and other connection settings
 	if settings.OwnMetrics != nil {
-		return agent.initMeter(settings.OwnMetrics)
+		err := agent.initMeter(settings.OwnMetrics)
+		status := protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED
+		errMsg := ""
+		if err != nil {
+			status = protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED
+			errMsg = err.Error()
+		}
+		agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+			LastConnectionSettingsHash: settings.Hash,
+			Status:                     status,
+			ErrorMessage:               errMsg,
+		})
+		return err
 	}
 	return nil
 }

--- a/internal/examples/agent/agent/agent.go
+++ b/internal/examples/agent/agent/agent.go
@@ -682,11 +682,13 @@ func (agent *Agent) tryChangeOpAMP(ctx context.Context, cert *tls.Certificate, t
 
 	if err := agent.connect(withTLSConfig(tlsConfig), withProxy(proxy)); err != nil {
 		agent.logger.Errorf(ctx, "Cannot connect after using new tls config: %s. Ignoring the offer\n", err)
-		if statusErr := agent.client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
+		status := &protobufs.ConnectionSettingsStatus{
 			LastConnectionSettingsHash: hash,
 			Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED,
 			ErrorMessage:               err.Error(),
-		}); statusErr != nil {
+		}
+
+		if statusErr := agent.client.SetConnectionSettingsStatus(status); statusErr != nil {
 			agent.logger.Errorf(ctx, "Failed to report connection settings status: %v", statusErr)
 		}
 		if err := agent.connect(withTLSConfig(oldCfg), withProxy(oldProxy)); err != nil {
@@ -702,7 +704,7 @@ func (agent *Agent) tryChangeOpAMP(ctx context.Context, cert *tls.Certificate, t
 	}); statusErr != nil {
 		agent.logger.Errorf(ctx, "Failed to report connection settings status: %v", statusErr)
 	}
-	// TODO: we can also persist the successfully accepted settigns and use it when the
+	// TODO: we can also persist the successfully accepted settings and use it when the
 	// agent connects to the server after the restart.
 }
 
@@ -765,6 +767,9 @@ func (agent *Agent) onOpampConnectionSettings(ctx context.Context, settings *pro
 		}
 	}
 	// TODO: also use settings.DestinationEndpoint and settings.Headers for future connections.
+	if len(agent.lastConnectionSettingsHash) == 0 {
+		return errors.New("cannot apply OpAMP connection settings without connection settings hash")
+	}
 	hash := make([]byte, len(agent.lastConnectionSettingsHash))
 	copy(hash, agent.lastConnectionSettingsHash)
 	go agent.tryChangeOpAMP(ctx, cert, tlsConfig, proxy, hash)
@@ -848,7 +853,7 @@ func toHeaders(ph *protobufs.Headers) http.Header {
 }
 
 func (agent *Agent) onConnectionSettings(ctx context.Context, settings *protobufs.ConnectionSettingsOffers) error {
-	agent.logger.Debugf(context.Background(), "Received connection settings offers from server, hash=%x.", settings.Hash)
+	agent.logger.Debugf(ctx, "Received connection settings offers from server, hash=%x.", settings.Hash)
 	// TODO handle traces, logs, and other connection settings
 	if settings.OwnMetrics != nil {
 		err := agent.initMeter(settings.OwnMetrics)
@@ -863,7 +868,7 @@ func (agent *Agent) onConnectionSettings(ctx context.Context, settings *protobuf
 			Status:                     status,
 			ErrorMessage:               errMsg,
 		}); statusErr != nil {
-			agent.logger.Errorf(context.Background(), "Failed to report connection settings status: %v", statusErr)
+			agent.logger.Errorf(ctx, "Failed to report connection settings status: %v", statusErr)
 		}
 		return err
 	}


### PR DESCRIPTION
Expose SetConnectionsSettingsStatus method in client interface to allow implementations that use async approaches to connection management to succeed instead of automatically setting APPLIED.

This change technically breaks an assumption we had in the initial implementation and passes the responsibility for setting the connectionsettingsstatus to the callback implementation.

The `client/internal/receivedprocessor.go` still sets the status to APPLYING if any connection settings are sent (and the reports connections settings status capability is set),

- Relates: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46157