### PR TITLE
Fix connection settings spec compliance issues

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -2738,6 +2738,193 @@ func TestValidateCapabilities(t *testing.T) {
 	}
 }
 
+func TestConnectionSettingsFilteredByCapability(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		metricsSettings := &protobufs.TelemetryConnectionSettings{DestinationEndpoint: "http://metrics.internal"}
+		tracesSettings := &protobufs.TelemetryConnectionSettings{DestinationEndpoint: "http://traces.internal"}
+		logsSettings := &protobufs.TelemetryConnectionSettings{DestinationEndpoint: "http://logs.internal"}
+		otherSettings := &protobufs.OtherConnectionSettings{DestinationEndpoint: "http://other.internal"}
+
+		srv := internal.StartMockServer(t)
+		firstMessage := true
+		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			if firstMessage {
+				firstMessage = false
+				return &protobufs.ServerToAgent{
+					InstanceUid: msg.InstanceUid,
+					ConnectionSettings: &protobufs.ConnectionSettingsOffers{
+						Hash:       []byte{1, 2, 3},
+						OwnMetrics: metricsSettings,
+						OwnTraces:  tracesSettings,
+						OwnLogs:    logsSettings,
+						OtherConnections: map[string]*protobufs.OtherConnectionSettings{
+							"other": otherSettings,
+						},
+					},
+				}
+			}
+			return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
+		}
+
+		var gotCallback atomic.Bool
+		// Only enable ReportsOwnMetrics — traces, logs, other should be filtered out.
+		settings := types.StartSettings{
+			OpAMPServerURL: "ws://" + srv.Endpoint,
+			Callbacks: types.Callbacks{
+				OnConnectionSettings: func(ctx context.Context, offers *protobufs.ConnectionSettingsOffers) error {
+					assert.NotNil(t, offers.OwnMetrics)
+					assert.Nil(t, offers.OwnTraces, "OwnTraces should be filtered out since ReportsOwnTraces capability is not set")
+					assert.Nil(t, offers.OwnLogs, "OwnLogs should be filtered out since ReportsOwnLogs capability is not set")
+					assert.Nil(t, offers.OtherConnections, "OtherConnections should be filtered out since AcceptsOtherConnectionSettings capability is not set")
+					gotCallback.Store(true)
+					return nil
+				},
+			},
+			Capabilities: protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnMetrics,
+		}
+		prepareClient(t, &settings, client)
+		assert.NoError(t, client.Start(t.Context(), settings))
+
+		eventually(t, func() bool { return gotCallback.Load() })
+
+		srv.Close()
+		err := client.Stop(t.Context())
+		assert.NoError(t, err)
+	})
+}
+
+func TestReportFullStateIncludesConnectionSettingsStatus(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		srv := internal.StartMockServer(t)
+		srv.EnableExpectMode()
+
+		hash := []byte{4, 5, 6}
+		connSettingsStatus := &protobufs.ConnectionSettingsStatus{
+			LastConnectionSettingsHash: hash,
+			Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
+		}
+
+		capabilities := protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig |
+			protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus |
+			protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnMetrics
+		settings := types.StartSettings{
+			OpAMPServerURL:               "ws://" + srv.Endpoint,
+			Capabilities:                 capabilities,
+			LastConnectionSettingsStatus: connSettingsStatus,
+		}
+		prepareClient(t, &settings, client)
+		assert.NoError(t, client.Start(t.Context(), settings))
+
+		// First message should include ConnectionSettingsStatus.
+		srv.Expect(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			assert.NotNil(t, msg.ConnectionSettingsStatus)
+			assert.True(t, proto.Equal(connSettingsStatus, msg.ConnectionSettingsStatus))
+			return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
+		})
+
+		// Trigger a status report to get a compressed message.
+		_ = client.UpdateEffectiveConfig(t.Context())
+
+		srv.Expect(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			// ConnectionSettingsStatus should be compressed (nil) since it hasn't changed.
+			assert.Nil(t, msg.ConnectionSettingsStatus)
+			// Ask for full state.
+			return &protobufs.ServerToAgent{
+				InstanceUid: msg.InstanceUid,
+				Flags:       uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState),
+			}
+		})
+
+		// Full state response should include ConnectionSettingsStatus.
+		srv.Expect(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			assert.NotNil(t, msg.ConnectionSettingsStatus, "ReportFullState response should include ConnectionSettingsStatus")
+			assert.True(t, proto.Equal(connSettingsStatus, msg.ConnectionSettingsStatus))
+			return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
+		})
+
+		srv.Close()
+		err := client.Stop(t.Context())
+		assert.NoError(t, err)
+	})
+}
+
+func TestConnectionSettingsSkippedWhenHashUnchanged(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		hash := []byte{7, 8, 9}
+		metricsSettings := &protobufs.TelemetryConnectionSettings{DestinationEndpoint: "http://metrics.internal"}
+
+		srv := internal.StartMockServer(t)
+		srv.EnableExpectMode()
+
+		var callbackCount atomic.Int64
+		settings := types.StartSettings{
+			OpAMPServerURL: "ws://" + srv.Endpoint,
+			Callbacks: types.Callbacks{
+				OnConnectionSettings: func(ctx context.Context, offers *protobufs.ConnectionSettingsOffers) error {
+					callbackCount.Add(1)
+					return nil
+				},
+			},
+			Capabilities: protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnMetrics |
+				protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus |
+				protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig,
+		}
+		prepareClient(t, &settings, client)
+		assert.NoError(t, client.Start(t.Context(), settings))
+
+		// First message from client: server offers connection settings.
+		srv.Expect(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			return &protobufs.ServerToAgent{
+				InstanceUid: msg.InstanceUid,
+				ConnectionSettings: &protobufs.ConnectionSettingsOffers{
+					Hash:       hash,
+					OwnMetrics: metricsSettings,
+				},
+			}
+		})
+
+		// Client sends APPLYING then APPLIED status. The server responds with the
+		// same connection settings hash each time. Eventually the callback count
+		// should stabilize at 1 because the hash-skip logic prevents reprocessing.
+		srv.EventuallyExpect("client reports APPLIED status",
+			func(msg *protobufs.AgentToServer) (*protobufs.ServerToAgent, bool) {
+				resp := &protobufs.ServerToAgent{
+					InstanceUid: msg.InstanceUid,
+					ConnectionSettings: &protobufs.ConnectionSettingsOffers{
+						Hash:       hash,
+						OwnMetrics: metricsSettings,
+					},
+				}
+				applied := msg.ConnectionSettingsStatus != nil &&
+					msg.ConnectionSettingsStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED
+				return resp, applied
+			},
+		)
+
+		// After APPLIED, trigger another exchange via UpdateEffectiveConfig.
+		// The server sends the same offers again — callback should NOT fire.
+		_ = client.UpdateEffectiveConfig(t.Context())
+
+		srv.Expect(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			return &protobufs.ServerToAgent{
+				InstanceUid: msg.InstanceUid,
+				ConnectionSettings: &protobufs.ConnectionSettingsOffers{
+					Hash:       hash,
+					OwnMetrics: metricsSettings,
+				},
+			}
+		})
+
+		// The callback should have been invoked exactly once (from the first offer).
+		assert.Equal(t, int64(1), callbackCount.Load(),
+			"Callback should only be invoked once for unchanged hash")
+
+		srv.Close()
+		err := client.Stop(t.Context())
+		assert.NoError(t, err)
+	})
+}
+
 func generateTestAvailableComponents() *protobufs.AvailableComponents {
 	return &protobufs.AvailableComponents{
 		Hash: []byte("fake-hash"),

--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -2915,9 +2915,16 @@ func TestConnectionSettingsSkippedWhenHashUnchanged(t *testing.T) {
 			}
 		})
 
-		// The callback should have been invoked exactly once (from the first offer).
-		assert.Equal(t, int64(1), callbackCount.Load(),
-			"Callback should only be invoked once for unchanged hash")
+		// The callback should have been invoked exactly once (from the first offer),
+		// and should remain stable after the repeated offer is processed.
+		require.Eventually(t, func() bool {
+			return callbackCount.Load() == 1
+		}, time.Second, 10*time.Millisecond,
+			"Callback should be invoked once for unchanged hash")
+		assert.Never(t, func() bool {
+			return callbackCount.Load() > 1
+		}, 200*time.Millisecond, 10*time.Millisecond,
+			"Callback should not be invoked again for unchanged hash")
 
 		srv.Close()
 		err := client.Stop(t.Context())

--- a/client/internal/clientstate.go
+++ b/client/internal/clientstate.go
@@ -40,11 +40,16 @@ type ClientSyncedState struct {
 	health                   *protobufs.ComponentHealth
 	remoteConfigStatus       *protobufs.RemoteConfigStatus
 	connectionSettingsStatus *protobufs.ConnectionSettingsStatus
-	packageStatuses          *protobufs.PackageStatuses
-	customCapabilities       *protobufs.CustomCapabilities
-	availableComponents      *protobufs.AvailableComponents
-	flags                    protobufs.AgentToServerFlags
-	agentCapabilities        protobufs.AgentCapabilities
+	// lastConnectionSettingsHash is the hash of the last ConnectionSettingsOffers
+	// the client processed. Tracked independently of connectionSettingsStatus so
+	// that hash-based skip logic works even when the ReportsConnectionSettingsStatus
+	// capability is not set.
+	lastConnectionSettingsHash []byte
+	packageStatuses            *protobufs.PackageStatuses
+	customCapabilities         *protobufs.CustomCapabilities
+	availableComponents        *protobufs.AvailableComponents
+	flags                      protobufs.AgentToServerFlags
+	agentCapabilities          protobufs.AgentCapabilities
 }
 
 func (s *ClientSyncedState) AgentDescription() *protobufs.AgentDescription {
@@ -69,6 +74,22 @@ func (s *ClientSyncedState) ConnectionSettingsStatus() *protobufs.ConnectionSett
 	defer s.mutex.Unlock()
 	s.mutex.Lock()
 	return s.connectionSettingsStatus
+}
+
+// LastConnectionSettingsHash returns the hash of the last ConnectionSettingsOffers
+// the client processed, or nil if none has been processed yet.
+func (s *ClientSyncedState) LastConnectionSettingsHash() []byte {
+	defer s.mutex.Unlock()
+	s.mutex.Lock()
+	return s.lastConnectionSettingsHash
+}
+
+// SetLastConnectionSettingsHash records the hash of the most recently processed
+// ConnectionSettingsOffers.
+func (s *ClientSyncedState) SetLastConnectionSettingsHash(hash []byte) {
+	defer s.mutex.Unlock()
+	s.mutex.Lock()
+	s.lastConnectionSettingsHash = hash
 }
 
 func (s *ClientSyncedState) PackageStatuses() *protobufs.PackageStatuses {

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -88,7 +88,8 @@ func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *pro
 		}
 	}
 
-	if msg.ConnectionSettings != nil {
+	processConnectionSettings := msg.ConnectionSettings != nil && r.connectionsSettingsHashChanged(ctx, msg.ConnectionSettings.Hash)
+	if processConnectionSettings {
 		msgData.OfferedConnectionsSettingsHash = msg.ConnectionSettings.Hash
 		if r.hasCapability(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus) {
 			connectionStatus := &protobufs.ConnectionSettingsStatus{
@@ -194,9 +195,11 @@ func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *pro
 
 	r.callbacks.OnMessage(ctx, msgData)
 
-	r.rcvOpampConnectionSettings(ctx, msg.ConnectionSettings)
+	if processConnectionSettings {
+		r.rcvOpampConnectionSettings(ctx, msg.ConnectionSettings)
 
-	r.rcvConnectionSettings(ctx, msg.ConnectionSettings)
+		r.rcvConnectionSettings(ctx, msg.ConnectionSettings)
+	}
 
 	if scheduled {
 		r.sender.ScheduleSend()
@@ -210,6 +213,25 @@ func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *pro
 
 func (r *receivedProcessor) hasCapability(capability protobufs.AgentCapabilities) bool {
 	return r.clientSyncedState.Capabilities()&capability != 0
+}
+
+// connectionsSettingsHashChanged returns true if the offered connection settings should
+// be processed. It returns false only when the hash matches the last applied hash,
+// indicating there is no need to reprocess the settings.
+func (r *receivedProcessor) connectionsSettingsHashChanged(ctx context.Context, hash []byte) bool {
+	if len(hash) == 0 {
+		return true
+	}
+	status := r.clientSyncedState.ConnectionSettingsStatus()
+	if status == nil {
+		return true
+	}
+	if status.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED &&
+		bytes.Equal(status.LastConnectionSettingsHash, hash) {
+		r.logger.Debugf(ctx, "Skipping ConnectionSettings processing, hash unchanged")
+		return false
+	}
+	return true
 }
 
 func (r *receivedProcessor) rcvFlags(
@@ -236,6 +258,9 @@ func (r *receivedProcessor) rcvFlags(
 				msg.CustomCapabilities = r.clientSyncedState.CustomCapabilities()
 				msg.Flags = r.clientSyncedState.Flags()
 				msg.AvailableComponents = r.clientSyncedState.AvailableComponents()
+				if r.hasCapability(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus) {
+					msg.ConnectionSettingsStatus = r.clientSyncedState.ConnectionSettingsStatus()
+				}
 
 				// The logic for EffectiveConfig is similar to the previous 6 sub-messages however
 				// the EffectiveConfig is fetched using GetEffectiveConfig instead of
@@ -335,7 +360,7 @@ func (r *receivedProcessor) rcvConnectionSettings(ctx context.Context, settings 
 	}
 
 	if clone.OwnMetrics != nil || clone.OwnTraces != nil || clone.OwnLogs != nil || clone.OtherConnections != nil {
-		err := r.callbacks.OnConnectionSettings(ctx, settings)
+		err := r.callbacks.OnConnectionSettings(ctx, clone)
 		if err != nil {
 			r.logger.Errorf(ctx, "Failed to process ConnectionSettings: %v", err)
 		}

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -88,9 +88,10 @@ func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *pro
 		}
 	}
 
-	processConnectionSettings := msg.ConnectionSettings != nil && r.connectionsSettingsHashChanged(ctx, msg.ConnectionSettings.Hash)
+	processConnectionSettings := msg.ConnectionSettings != nil && r.connectionSettingsHashChanged(ctx, msg.ConnectionSettings.Hash)
 	if processConnectionSettings {
 		msgData.OfferedConnectionsSettingsHash = msg.ConnectionSettings.Hash
+		r.clientSyncedState.SetLastConnectionSettingsHash(msg.ConnectionSettings.Hash)
 		if r.hasCapability(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus) {
 			connectionStatus := &protobufs.ConnectionSettingsStatus{
 				LastConnectionSettingsHash: msg.ConnectionSettings.Hash,
@@ -215,19 +216,14 @@ func (r *receivedProcessor) hasCapability(capability protobufs.AgentCapabilities
 	return r.clientSyncedState.Capabilities()&capability != 0
 }
 
-// connectionsSettingsHashChanged returns true if the offered connection settings should
-// be processed. It returns false only when the hash matches the last applied hash,
-// indicating there is no need to reprocess the settings.
-func (r *receivedProcessor) connectionsSettingsHashChanged(ctx context.Context, hash []byte) bool {
+// connectionSettingsHashChanged returns true if the offered connection settings
+// should be processed. It returns false when the offered hash matches the last
+// processed hash, indicating there is no need to reprocess the settings.
+func (r *receivedProcessor) connectionSettingsHashChanged(ctx context.Context, hash []byte) bool {
 	if len(hash) == 0 {
 		return true
 	}
-	status := r.clientSyncedState.ConnectionSettingsStatus()
-	if status == nil {
-		return true
-	}
-	if status.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED &&
-		bytes.Equal(status.LastConnectionSettingsHash, hash) {
+	if bytes.Equal(r.clientSyncedState.LastConnectionSettingsHash(), hash) {
 		r.logger.Debugf(ctx, "Skipping ConnectionSettings processing, hash unchanged")
 		return false
 	}


### PR DESCRIPTION
## Summary

- **Pass capability-filtered settings to OnConnectionSettings callback**: `rcvConnectionSettings` was creating a filtered `clone` with unsupported capability fields nullified, but then passing the original unfiltered `settings` to the callback. Now passes `clone`.
- **Include ConnectionSettingsStatus in ReportFullState response**: The `ReportFullState` handler was missing `ConnectionSettingsStatus` from the full state report, causing the server to lose connection settings state after requesting a full resync. Now included when `ReportsConnectionSettingsStatus` capability is set.
- **Skip reprocessing unchanged connection settings**: When the server resends `ConnectionSettingsOffers` with the same hash as the last applied settings, the client now skips reprocessing instead of re-invoking callbacks and setting APPLYING status again.


🤖 Generated with [Claude Code](https://claude.com/claude-code)