### PR TITLE
chore: typo fixes `succesful`/`recieve` in client package

### DIFF
--- a/client/internal/package_download_details_reporter_test.go
+++ b/client/internal/package_download_details_reporter_test.go
@@ -37,7 +37,7 @@ func Test_DownloadReporter_Report(t *testing.T) {
 	select {
 	case details = <-ch:
 	case <-time.After(time.Millisecond * 100):
-		t.Fatal("Did not recieve report after 100ms")
+		t.Fatal("Did not receive report after 100ms")
 	}
 
 	require.Equal(t, 50, int(details.DownloadPercent))

--- a/client/types/callbacks.go
+++ b/client/types/callbacks.go
@@ -138,7 +138,7 @@ type Callbacks struct {
 	// The callback must return a non-nil HTTP client or an error.
 	DownloadHTTPClient func(ctx context.Context, file *protobufs.DownloadableFile) (*http.Client, error)
 
-	// OnConnectionSettings is called when the agent recieves any non OpAMP
+	// OnConnectionSettings is called when the agent receives any non OpAMP
 	// connection settings.
 	//
 	// The Agent should process the offer by reconnecting the client using the new

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -57,7 +57,7 @@ type wsClient struct {
 	connShutdownTimeout time.Duration
 
 	// responseChain is used for the "via" argument in CheckRedirect.
-	// It is appended to with every redirect followed, and zeroed on a succesful
+	// It is appended to with every redirect followed, and zeroed on a successful
 	// connection. responseChain should only be referred to by the goroutine that
 	// runs tryConnectOnce and its synchronous callees.
 	responseChain []*http.Response


### PR DESCRIPTION
- `client/wsclient.go:60` — comment `succesful` -> `successful`
- `client/types/callbacks.go:141` — `OnConnectionSettings` doc comment `recieves` -> `receives`
- `client/internal/package_download_details_reporter_test.go:40` — `t.Fatal` message `recieve` -> `receive`

No functional change. `go build ./...` + relevant package tests pass locally.