### PR TITLE
Fix/invoke header func per retry

### DIFF
--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -37,7 +37,8 @@ const (
 type requestWrapper struct {
 	*http.Request
 
-	bodyReader func() io.ReadCloser
+	bodyReader  func() io.ReadCloser
+	instanceUID string
 }
 
 func bodyReader(buf []byte) func() io.ReadCloser {
@@ -350,14 +351,12 @@ func (h *HTTPSender) prepareRequest(ctx context.Context) (*requestWrapper, error
 		req.bodyReader = bodyReader(data)
 	}
 
-	req.Header = h.getHeader()
-
 	if msgToSend.InstanceUid != nil {
 		uid, err := uuid.FromBytes(msgToSend.InstanceUid)
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set(headerOpAMPInstanceUID, uid.String())
+		req.instanceUID = uid.String()
 	}
 
 	return &req, nil

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -266,6 +266,7 @@ func (h *HTTPSender) sendRequestWithRetries(ctx context.Context) (*http.Response
 // whether to retry or return.
 func (h *HTTPSender) attemptRequest(ctx context.Context, req *requestWrapper, currentInterval time.Duration) requestResult {
 	req.rewind(ctx)
+	h.applyHeaders(req)
 
 	resp, err := h.client.Do(req.Request)
 	if err != nil {
@@ -360,6 +361,19 @@ func (h *HTTPSender) prepareRequest(ctx context.Context) (*requestWrapper, error
 	}
 
 	return &req, nil
+}
+
+// applyHeaders sets the outgoing request headers by invoking the configured
+// HeaderFunc and layering the per-request instance UID on top. Called from
+// attemptRequest before each HTTP request actually goes on the wire, so that
+// time-sensitive headers (e.g. short-lived JWTs in Authorization) are
+// regenerated per attempt — honoring the contract set by
+// StartSettings.HeaderFunc (see #297 / PR #298).
+func (h *HTTPSender) applyHeaders(req *requestWrapper) {
+	req.Header = h.getHeader()
+	if req.instanceUID != "" {
+		req.Header.Set(headerOpAMPInstanceUID, req.instanceUID)
+	}
 }
 
 func (h *HTTPSender) receiveResponse(ctx context.Context, resp *http.Response) {

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -766,6 +766,7 @@ func TestHTTPSenderHeaderFuncInvokedOnRetry(t *testing.T) {
 
 	var connectionAttempts atomic.Int64
 	srv := StartMockServer(t)
+	t.Cleanup(srv.Close)
 	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		observedAuthHeaders = append(observedAuthHeaders, r.Header.Get("Authorization"))
@@ -802,7 +803,6 @@ func TestHTTPSenderHeaderFuncInvokedOnRetry(t *testing.T) {
 	resp, err := sender.sendRequestWithRetries(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	srv.Close()
 
 	// HeaderFunc must have been invoked once per outgoing HTTP request.
 	require.Equal(t, int64(3), connectionAttempts.Load(), "expected 3 HTTP attempts")

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -764,13 +764,13 @@ func TestHTTPSenderHeaderFuncInvokedOnRetry(t *testing.T) {
 		return h
 	}
 
-	var connectionAttempts int64
+	var connectionAttempts atomic.Int64
 	srv := StartMockServer(t)
 	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		observedAuthHeaders = append(observedAuthHeaders, r.Header.Get("Authorization"))
 		mu.Unlock()
-		attempt := atomic.AddInt64(&connectionAttempts, 1)
+		attempt := connectionAttempts.Add(1)
 		// Fail the first two attempts with a retryable status, then succeed.
 		if attempt < 3 {
 			w.Header().Set("Retry-After", "0")
@@ -807,7 +807,7 @@ func TestHTTPSenderHeaderFuncInvokedOnRetry(t *testing.T) {
 	srv.Close()
 
 	// HeaderFunc must have been invoked once per outgoing HTTP request.
-	require.Equal(t, int64(3), atomic.LoadInt64(&connectionAttempts), "expected 3 HTTP attempts")
+	require.Equal(t, int64(3), connectionAttempts.Load(), "expected 3 HTTP attempts")
 	require.Equal(t, int64(3), headerFuncCalls.Load(), "HeaderFunc must be invoked once per attempt (#297 contract)")
 
 	// The three attempts must have carried three distinct Authorization values —

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -741,4 +742,80 @@ func TestHTTPSenderOpAMPInstanceUIDHeader(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	srv.Close()
+}
+
+// TestHTTPSenderHeaderFuncInvokedOnRetry verifies that HeaderFunc is invoked
+// for every HTTP request actually put on the wire, including retry attempts.
+// See #297 / PR #298: HeaderFunc was introduced to let callers regenerate
+// time-sensitive headers (e.g. short-lived JWTs in Authorization) per request.
+// The retry loop historically reused a pre-built *requestWrapper so retries
+// carried the same Authorization header as the first attempt — negating the
+// feature's stated intent under any retry that spans longer than the token TTL.
+func TestHTTPSenderHeaderFuncInvokedOnRetry(t *testing.T) {
+	var headerFuncCalls int64
+	var observedAuthHeaders []string
+	var mu sync.Mutex
+
+	// HeaderFunc embeds the call count in the Authorization header so we can
+	// prove each outgoing request carried a fresh-at-call-time value.
+	headerFunc := func(h http.Header) http.Header {
+		n := atomic.AddInt64(&headerFuncCalls, 1)
+		h.Set("Authorization", fmt.Sprintf("Bearer token-%d", n))
+		return h
+	}
+
+	var connectionAttempts int64
+	srv := StartMockServer(t)
+	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		observedAuthHeaders = append(observedAuthHeaders, r.Header.Get("Authorization"))
+		mu.Unlock()
+		attempt := atomic.AddInt64(&connectionAttempts, 1)
+		// Fail the first two attempts with a retryable status, then succeed.
+		if attempt < 3 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+
+	url := "http://" + srv.Endpoint
+	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender.SetRequestHeader(nil, headerFunc)
+	sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
+		msg.AgentDescription = &protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{{
+				Key: "service.name",
+				Value: &protobufs.AnyValue{
+					Value: &protobufs.AnyValue_StringValue{StringValue: "test-service"},
+				},
+			}},
+		}
+	})
+	sender.callbacks = types.Callbacks{
+		OnConnect:       func(ctx context.Context) {},
+		OnConnectFailed: func(ctx context.Context, _ error) {},
+	}
+	sender.url = url
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp, err := sender.sendRequestWithRetries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	srv.Close()
+
+	// HeaderFunc must have been invoked once per outgoing HTTP request.
+	require.Equal(t, int64(3), atomic.LoadInt64(&connectionAttempts), "expected 3 HTTP attempts")
+	require.Equal(t, int64(3), atomic.LoadInt64(&headerFuncCalls), "HeaderFunc must be invoked once per attempt (#297 contract)")
+
+	// The three attempts must have carried three distinct Authorization values —
+	// proving retries did not reuse the header captured on attempt 1.
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, observedAuthHeaders, 3)
+	require.Equal(t, "Bearer token-1", observedAuthHeaders[0])
+	require.Equal(t, "Bearer token-2", observedAuthHeaders[1])
+	require.Equal(t, "Bearer token-3", observedAuthHeaders[2])
 }

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -752,14 +752,14 @@ func TestHTTPSenderOpAMPInstanceUIDHeader(t *testing.T) {
 // carried the same Authorization header as the first attempt — negating the
 // feature's stated intent under any retry that spans longer than the token TTL.
 func TestHTTPSenderHeaderFuncInvokedOnRetry(t *testing.T) {
-	var headerFuncCalls int64
+	var headerFuncCalls atomic.Int64
 	var observedAuthHeaders []string
 	var mu sync.Mutex
 
 	// HeaderFunc embeds the call count in the Authorization header so we can
 	// prove each outgoing request carried a fresh-at-call-time value.
 	headerFunc := func(h http.Header) http.Header {
-		n := atomic.AddInt64(&headerFuncCalls, 1)
+		n := headerFuncCalls.Add(1)
 		h.Set("Authorization", fmt.Sprintf("Bearer token-%d", n))
 		return h
 	}
@@ -808,7 +808,7 @@ func TestHTTPSenderHeaderFuncInvokedOnRetry(t *testing.T) {
 
 	// HeaderFunc must have been invoked once per outgoing HTTP request.
 	require.Equal(t, int64(3), atomic.LoadInt64(&connectionAttempts), "expected 3 HTTP attempts")
-	require.Equal(t, int64(3), atomic.LoadInt64(&headerFuncCalls), "HeaderFunc must be invoked once per attempt (#297 contract)")
+	require.Equal(t, int64(3), headerFuncCalls.Load(), "HeaderFunc must be invoked once per attempt (#297 contract)")
 
 	// The three attempts must have carried three distinct Authorization values —
 	// proving retries did not reuse the header captured on attempt 1.

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -799,9 +799,7 @@ func TestHTTPSenderHeaderFuncInvokedOnRetry(t *testing.T) {
 	}
 	sender.url = url
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	resp, err := sender.sendRequestWithRetries(ctx)
+	resp, err := sender.sendRequestWithRetries(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	srv.Close()


### PR DESCRIPTION
Opening this PR to resolve the issue reported in https://github.com/open-telemetry/opamp-go/issues/551 .