### PR TITLE
Add a timeout setting for client HTTP requests

### DIFF
--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -51,6 +51,10 @@ func (c *httpClient) Start(ctx context.Context, settings types.StartSettings) er
 	// Add TLS configuration into httpClient
 	c.sender.AddTLSConfig(settings.TLSConfig)
 
+	if settings.HTTPRequestTimeout > 0 {
+		c.sender.SetRequestTimeout(settings.HTTPRequestTimeout)
+	}
+
 	if settings.EnableCompression {
 		c.sender.EnableCompression()
 	}

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -230,6 +230,57 @@ func TestHTTPClientStartWithZeroHeartbeatInterval(t *testing.T) {
 	srv.Close()
 }
 
+func TestHTTPClientStartWithRequestTimeout(t *testing.T) {
+	srv := internal.StartMockServer(t)
+	defer srv.Close()
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	connectFailed := make(chan error, 1)
+	var requestStartedClosed atomic.Bool
+
+	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
+		if requestStartedClosed.CompareAndSwap(false, true) {
+			close(requestStarted)
+		}
+		<-releaseRequest
+	}
+
+	settings := types.StartSettings{
+		OpAMPServerURL:     "http://" + srv.Endpoint,
+		HTTPRequestTimeout: 100 * time.Millisecond,
+		Callbacks: types.Callbacks{
+			OnConnectFailed: func(ctx context.Context, err error) {
+				select {
+				case connectFailed <- err:
+				default:
+				}
+			},
+		},
+	}
+	client := NewHTTP(nil)
+	prepareClient(t, &settings, client)
+
+	require.NoError(t, client.Start(context.Background(), settings))
+	defer func() {
+		assert.NoError(t, client.Stop(context.Background()))
+	}()
+	defer close(releaseRequest)
+
+	select {
+	case <-requestStarted:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "timed out waiting for HTTP request")
+	}
+
+	select {
+	case err := <-connectFailed:
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "timed out waiting for connect failure")
+	}
+}
+
 func mockRedirectHTTP(t testing.TB, viaLen int, err error) *checkRedirectMock {
 	m := &checkRedirectMock{
 		t:      t,

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -115,6 +115,12 @@ func (h *HTTPSender) SetProxy(proxy string, headers http.Header) error {
 	return nil
 }
 
+// SetRequestTimeout sets the timeout for individual HTTP requests made by the sender.
+// It should only be called before Run is called.
+func (h *HTTPSender) SetRequestTimeout(timeout time.Duration) {
+	h.client.Timeout = timeout
+}
+
 // Run starts the processing loop that will perform the HTTP request/response.
 // When there are no more messages to send Run will suspend until either there is
 // a new message to send or the polling interval elapses.

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -26,6 +26,10 @@ type StartSettings struct {
 	// Optional TLS config for HTTP connection.
 	TLSConfig *tls.Config
 
+	// Optional timeout for each HTTP request performed by the plain HTTP transport.
+	// If zero, no request timeout is set.
+	HTTPRequestTimeout time.Duration
+
 	// Optional Proxy configuration
 	// The ProxyURL may be http(s) or socks5; if no schema is specified http is assumed.
 	ProxyURL string

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -26,7 +26,7 @@ type StartSettings struct {
 	// Optional TLS config for HTTP connection.
 	TLSConfig *tls.Config
 
-	// Optional timeout for each HTTP request performed by the plain HTTP transport.
+	// Optional timeout for each request performed by the HTTP transport.
 	// If zero, no request timeout is set.
 	HTTPRequestTimeout time.Duration
 


### PR DESCRIPTION
This gives the ability to properly recover from cases where an intermediate proxy or server misbehaves by spuriously stopping responding on a connection without actually closing it, causing an indefinite hang. With a request timeout set, this can be recovered from, as it would just cause a failed request and then attempt to reconnect.

This was encountered in a real case, specifically due to a misbehaving proxy in that case. I've created a synthetic reproduction case demo that can shows the hang with request timeout unset, and the recovery with it set:
https://gist.github.com/agoallikmaa/fb8a8eb0e33ab8fab995132d2ce76250

The `receivedprocessor.go` change is just to fix current main branch build issue.