### PR TITLE
Fix redirect test

### DIFF
--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -250,16 +250,16 @@ func TestRedirectHTTP(t *testing.T) {
 	}{
 		{
 			Name:       "simple redirect",
-			Redirector: redirectServer("http://"+redirectee.Endpoint, 302),
+			Redirector: redirectServer("http://"+redirectee.Endpoint, http.StatusTemporaryRedirect),
 		},
 		{
 			Name:         "check redirect",
-			Redirector:   redirectServer("http://"+redirectee.Endpoint, 302),
+			Redirector:   redirectServer("http://"+redirectee.Endpoint, http.StatusTemporaryRedirect),
 			MockRedirect: mockRedirectHTTP(t, 1, nil),
 		},
 		{
 			Name:         "check redirect returns error",
-			Redirector:   redirectServer("http://"+redirectee.Endpoint, 302),
+			Redirector:   redirectServer("http://"+redirectee.Endpoint, http.StatusTemporaryRedirect),
 			MockRedirect: mockRedirectHTTP(t, 1, errors.New("hello")),
 			ExpError:     true,
 		},

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -349,6 +349,9 @@ func (h *HTTPSender) prepareRequest(ctx context.Context) (*requestWrapper, error
 	} else {
 		req.bodyReader = bodyReader(data)
 	}
+	// Set GetBody so the standard library can replay the body when following
+	// 307/308 redirects (which preserve the request method).
+	r.GetBody = func() (io.ReadCloser, error) { return req.bodyReader(), nil }
 
 	req.Header = h.getHeader()
 

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -328,7 +328,7 @@ func TestVerifyWSCompress(t *testing.T) {
 
 func redirectServer(to string, status int) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		http.Redirect(w, req, to, http.StatusSeeOther)
+		http.Redirect(w, req, to, status)
 	}))
 }
 


### PR DESCRIPTION
Fix redirect test by returning passed status instead of `StatusSeeOther`.
Set `request.GetBody` for HTTP clients in order to properly handle POST requests that are re-directed.