### PR TITLE
chore: Pass `downloadURL` to `UpdateContent`

### DIFF
--- a/client/internal/inmempackagestore.go
+++ b/client/internal/inmempackagestore.go
@@ -68,7 +68,7 @@ func (l *InMemPackagesStore) FileContentHash(packageName string) ([]byte, error)
 	return l.fileHashes[packageName], nil
 }
 
-func (l *InMemPackagesStore) UpdateContent(_ context.Context, packageName string, data io.Reader, contentHash, signature []byte) error {
+func (l *InMemPackagesStore) UpdateContent(_ context.Context, packageName, _ string, data io.Reader, contentHash, signature []byte) error {
 	b, err := io.ReadAll(data)
 	if err != nil {
 		return err

--- a/client/internal/packagessyncer.go
+++ b/client/internal/packagessyncer.go
@@ -329,7 +329,7 @@ func (s *packagesSyncer) downloadFile(ctx context.Context, pkgName string, file 
 	defer detailsReporter.stop()
 
 	tr := io.TeeReader(resp.Body, detailsReporter)
-	err = s.localState.UpdateContent(ctx, pkgName, tr, file.ContentHash, file.Signature)
+	err = s.localState.UpdateContent(ctx, pkgName, file.GetDownloadUrl(), tr, file.ContentHash, file.Signature)
 	if err != nil {
 		return fmt.Errorf("failed to install/update the package %s downloaded from %s: %v", pkgName, file.DownloadUrl, err)
 	}

--- a/client/types/packagessyncer.go
+++ b/client/types/packagessyncer.go
@@ -77,6 +77,9 @@ type PackagesStateProvider interface {
 	// an error.
 	// Content hash must be updated if the data is updated without failure.
 	// The function must cancel and return an error if the context is cancelled.
+	// downloadURL is the URL the content was downloaded from. Implementations may
+	// inspect its path suffix (e.g. ".tar.gz", ".zip") to decide how to interpret or
+	// unpack the content.
 	UpdateContent(ctx context.Context, packageName, downloadURL string, data io.Reader, contentHash, signature []byte) error
 
 	// DeletePackage deletes the package from the Agent's local storage.

--- a/client/types/packagessyncer.go
+++ b/client/types/packagessyncer.go
@@ -77,7 +77,7 @@ type PackagesStateProvider interface {
 	// an error.
 	// Content hash must be updated if the data is updated without failure.
 	// The function must cancel and return an error if the context is cancelled.
-	UpdateContent(ctx context.Context, packageName string, data io.Reader, contentHash, signature []byte) error
+	UpdateContent(ctx context.Context, packageName, downloadURL string, data io.Reader, contentHash, signature []byte) error
 
 	// DeletePackage deletes the package from the Agent's local storage.
 	DeletePackage(packageName string) error


### PR DESCRIPTION
This change is based on feedback left on this [PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47300#discussion_r3197221917) adding Package upgrades to the OpAMP Supervisor.

This adds a new parameter, `downloadURL`, to the `PacakgesStateProvider.UpdateContent` function. When the OpAMP client is handling a PackagesAvailable message, it retrieves the data found at `downloadURL` and places it in the `data io.Reader` parameter that is passed to `UpdateContent`. The issue with this is this function doens't know what kind of data is in this reader (e.g. if it's compressed or what archive type it is). Without this information, `UpdateContent` can't properly handle the data. By passing `downloadURL` we can inspect the url's suffix to infer the package type.