### PR TITLE
Add HTTP client to StartSettings

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -95,6 +95,28 @@ func eventually(t *testing.T, f func() bool) {
 	assert.Eventually(t, f, 5*time.Second, 10*time.Millisecond)
 }
 
+type mockServerMessageHandler func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent
+
+type mockServerMessageDispatcher struct {
+	handler atomic.Value
+}
+
+func newMockServerMessageDispatcher() *mockServerMessageDispatcher {
+	dispatcher := &mockServerMessageDispatcher{}
+	dispatcher.Set(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
+	})
+	return dispatcher
+}
+
+func (d *mockServerMessageDispatcher) Set(handler mockServerMessageHandler) {
+	d.handler.Store(handler)
+}
+
+func (d *mockServerMessageDispatcher) Handle(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	return d.handler.Load().(mockServerMessageHandler)(msg)
+}
+
 func genNewInstanceUid(t *testing.T) types.InstanceUid {
 	uid, err := uuid.NewV7()
 	require.NoError(t, err)
@@ -2960,11 +2982,11 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 		name         string
 		capabilities protobufs.AgentCapabilities
 		needsServer  bool
-		testFunc     func(t *testing.T, client OpAMPClient, srv *internal.MockServer)
+		testFunc     func(t *testing.T, client OpAMPClient, srv *internal.MockServer, setOnMessage func(mockServerMessageHandler))
 	}{{
 		name:         "no capability returns error",
 		capabilities: coreCapabilities,
-		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer) {
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer, _ func(mockServerMessageHandler)) {
 			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
 				LastConnectionSettingsHash: []byte{1, 2, 3},
 				Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
@@ -2974,14 +2996,14 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 	}, {
 		name:         "nil status returns error",
 		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
-		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer) {
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer, _ func(mockServerMessageHandler)) {
 			err := client.SetConnectionSettingsStatus(nil)
 			require.Error(t, err)
 		},
 	}, {
 		name:         "nil hash returns error",
 		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
-		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer) {
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer, _ func(mockServerMessageHandler)) {
 			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
 				Status: protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED,
 			})
@@ -2991,15 +3013,15 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 		name:         "sends status to server",
 		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
 		needsServer:  true,
-		testFunc: func(t *testing.T, client OpAMPClient, srv *internal.MockServer) {
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer, setOnMessage func(mockServerMessageHandler)) {
 			gotApplied := new(atomic.Bool)
-			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			setOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				if msg.ConnectionSettingsStatus != nil &&
 					msg.ConnectionSettingsStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED {
 					gotApplied.Store(true)
 				}
 				return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
-			}
+			})
 
 			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
 				LastConnectionSettingsHash: []byte{1, 2, 3},
@@ -3012,15 +3034,15 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 		name:         "duplicate status is no-op",
 		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
 		needsServer:  true,
-		testFunc: func(t *testing.T, client OpAMPClient, srv *internal.MockServer) {
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer, setOnMessage func(mockServerMessageHandler)) {
 			var appliedCount atomic.Int64
-			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			setOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				if msg.ConnectionSettingsStatus != nil &&
 					msg.ConnectionSettingsStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED {
 					appliedCount.Add(1)
 				}
 				return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
-			}
+			})
 
 			status := &protobufs.ConnectionSettingsStatus{
 				LastConnectionSettingsHash: []byte{1, 2, 3},
@@ -3042,15 +3064,15 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 		name:         "sends FAILED status to server",
 		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
 		needsServer:  true,
-		testFunc: func(t *testing.T, client OpAMPClient, srv *internal.MockServer) {
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer, setOnMessage func(mockServerMessageHandler)) {
 			gotFailed := new(atomic.Bool)
-			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			setOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				if msg.ConnectionSettingsStatus != nil &&
 					msg.ConnectionSettingsStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED {
 					gotFailed.Store(true)
 				}
 				return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
-			}
+			})
 
 			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
 				LastConnectionSettingsHash: []byte{1, 2, 3},
@@ -3064,15 +3086,15 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 		name:         "different hash triggers send",
 		capabilities: coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus,
 		needsServer:  true,
-		testFunc: func(t *testing.T, client OpAMPClient, srv *internal.MockServer) {
+		testFunc: func(t *testing.T, client OpAMPClient, _ *internal.MockServer, setOnMessage func(mockServerMessageHandler)) {
 			var appliedCount atomic.Int64
-			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			setOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				if msg.ConnectionSettingsStatus != nil &&
 					msg.ConnectionSettingsStatus.Status == protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLIED {
 					appliedCount.Add(1)
 				}
 				return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
-			}
+			})
 
 			// First call with hash A.
 			err := client.SetConnectionSettingsStatus(&protobufs.ConnectionSettingsStatus{
@@ -3097,10 +3119,14 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 			testClients(t, func(t *testing.T, client OpAMPClient) {
 				var srv *internal.MockServer
 				var settings types.StartSettings
+				setOnMessage := func(mockServerMessageHandler) {}
 
 				if tc.needsServer {
 					srv = internal.StartMockServer(t)
 					defer srv.Close()
+					messageDispatcher := newMockServerMessageDispatcher()
+					srv.OnMessage = messageDispatcher.Handle
+					setOnMessage = messageDispatcher.Set
 					settings.OpAMPServerURL = "ws://" + srv.Endpoint
 				} else {
 					settings = createNoServerSettings()
@@ -3108,7 +3134,7 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 				settings.Capabilities = tc.capabilities
 
 				startClient(t, settings, client)
-				tc.testFunc(t, client, srv)
+				tc.testFunc(t, client, srv, setOnMessage)
 
 				err := client.Stop(t.Context())
 				require.NoError(t, err)

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/open-telemetry/opamp-go/client/internal"
+	"github.com/open-telemetry/opamp-go/client/internal/utils"
 	"github.com/open-telemetry/opamp-go/client/types"
 	sharedinternal "github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -44,6 +45,12 @@ func (c *httpClient) Start(ctx context.Context, settings types.StartSettings) er
 	}
 
 	c.opAMPServerURL = settings.OpAMPServerURL
+
+	httpClient := settings.Client
+	if httpClient == nil {
+		httpClient = utils.NewHttpClient()
+	}
+	c.sender.SetHTTPClient(httpClient)
 
 	// Prepare Server connection settings.
 	c.sender.SetRequestHeader(settings.Header, settings.HeaderFunc)

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -23,6 +23,51 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
+type recordingRoundTripper struct {
+	base     http.RoundTripper
+	requests int64
+}
+
+func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	atomic.AddInt64(&r.requests, 1)
+	return r.base.RoundTrip(req)
+}
+
+func (r *recordingRoundTripper) RequestCount() int64 {
+	return atomic.LoadInt64(&r.requests)
+}
+
+func TestHTTPClientUsesStartSettingsClient(t *testing.T) {
+	srv := internal.StartMockServer(t)
+	defer srv.Close()
+
+	var rcvCounter int64
+	srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		require.NotNil(t, msg)
+		atomic.AddInt64(&rcvCounter, 1)
+		return nil
+	}
+
+	transport := &recordingRoundTripper{base: http.DefaultTransport}
+	settings := types.StartSettings{
+		OpAMPServerURL: "http://" + srv.Endpoint,
+		Client:         &http.Client{Transport: transport},
+	}
+	client := NewHTTP(nil)
+	prepareClient(t, &settings, client)
+
+	client.sender.SetPollingInterval(time.Millisecond * 10)
+
+	require.NoError(t, client.Start(context.Background(), settings))
+	defer func() {
+		require.NoError(t, client.Stop(context.Background()))
+	}()
+
+	eventually(t, func() bool {
+		return atomic.LoadInt64(&rcvCounter) >= 1 && transport.RequestCount() >= 1
+	})
+}
+
 func TestHTTPPolling(t *testing.T) {
 	// Start a Server.
 	srv := internal.StartMockServer(t)

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -18,7 +18,6 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/open-telemetry/opamp-go/client/internal/utils"
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -78,12 +77,17 @@ func NewHTTPSender(logger types.Logger) *HTTPSender {
 	h := &HTTPSender{
 		SenderCommon: NewSenderCommon(),
 		logger:       logger,
-		client:       utils.NewHttpClient(),
 	}
 	h.pollingIntervalMs.Store(defaultPollingIntervalMs)
 	// initialize the headers with no additional headers
 	h.SetRequestHeader(nil, nil)
 	return h
+}
+
+// SetHTTPClient sets the HTTP client used to send OpAMP requests.
+// It must be called before Run, SetProxy, or AddTLSConfig.
+func (h *HTTPSender) SetHTTPClient(client *http.Client) {
+	h.client = client
 }
 
 // SetProxy will force each request to use passed proxy and use the passed headers when making a CONNECT request to the proxy.

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -23,6 +23,12 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
+func newTestHTTPSender() *HTTPSender {
+	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender.SetHTTPClient(&http.Client{})
+	return sender
+}
+
 func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
 	var connectionAttempts int64
 	srv := StartMockServer(t)
@@ -38,7 +44,7 @@ func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	url := "http://" + srv.Endpoint
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender := newTestHTTPSender()
 	sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
 		msg.AgentDescription = &protobufs.AgentDescription{
 			IdentifyingAttributes: []*protobufs.KeyValue{{
@@ -66,7 +72,7 @@ func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
 }
 
 func TestHTTPSenderSetHeartbeatInterval(t *testing.T) {
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender := newTestHTTPSender()
 
 	// Default interval should be 30s as per OpAMP Specification
 	assert.Equal(t, (30 * time.Second).Milliseconds(), sender.pollingIntervalMs.Load())
@@ -169,7 +175,7 @@ func TestAddTLSConfig(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sender := NewHTTPSender(&sharedinternal.NopLogger{})
+			sender := newTestHTTPSender()
 			sender.client.Transport = tc.existingTransport
 
 			sender.AddTLSConfig(tc.tlsConfig)
@@ -233,7 +239,7 @@ func TestHTTPSenderRetryForFailedRequests(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	url := "http://" + address
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender := newTestHTTPSender()
 	sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
 		msg.AgentDescription = &protobufs.AgentDescription{
 			IdentifyingAttributes: []*protobufs.KeyValue{{
@@ -277,7 +283,7 @@ func TestHTTPSenderRetryForFailedRequests(t *testing.T) {
 func TestRequestInstanceUidFlagReset(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender := newTestHTTPSender()
 	sender.callbacks = types.Callbacks{}
 	sender.callbacks.SetDefaults()
 
@@ -315,7 +321,7 @@ func TestRequestInstanceUidFlagReset(t *testing.T) {
 func TestPackageUpdatesInParallel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	localPackageState := NewInMemPackagesStore()
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender := newTestHTTPSender()
 	blockSyncCh := make(chan struct{})
 	doneCh := make([]<-chan struct{}, 0)
 
@@ -399,7 +405,7 @@ func TestPackageUpdatesInParallel(t *testing.T) {
 
 func TestPackageUpdatesWithError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender := newTestHTTPSender()
 
 	// We'll pass in a nil PackageStateProvider to force the Sync call to return with an error.
 	localPackageState := types.PackagesStateProvider(nil)
@@ -469,7 +475,7 @@ func TestHTTPSenderSetProxy(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sender := NewHTTPSender(&sharedinternal.NopLogger{})
+			sender := newTestHTTPSender()
 			err := sender.SetProxy(tc.url, nil)
 			if tc.err != nil {
 				assert.ErrorAs(t, err, &tc.err)
@@ -552,7 +558,7 @@ func TestHTTPSenderSetProxy(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}
 
-		sender := NewHTTPSender(&sharedinternal.NopLogger{})
+		sender := newTestHTTPSender()
 		sender.client = proxyServer.Client()
 		err := sender.SetProxy(proxyServer.URL, http.Header{"test-header": []string{"test-value"}})
 		assert.NoError(t, err)
@@ -696,7 +702,7 @@ func (b *closeTrackingBodyWrapper) Close() error {
 
 // setupTestSender creates a test HTTPSender with a standard message.
 func setupTestSender(_ *testing.T, url string) *HTTPSender {
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender := newTestHTTPSender()
 	sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
 		msg.AgentDescription = &protobufs.AgentDescription{
 			IdentifyingAttributes: []*protobufs.KeyValue{{
@@ -724,7 +730,7 @@ func TestHTTPSenderOpAMPInstanceUIDHeader(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}
 	url := "http://" + srv.Endpoint
-	sender := NewHTTPSender(&sharedinternal.NopLogger{})
+	sender := newTestHTTPSender()
 
 	// Make sure requests contain the Instance UID. Header value will be populated
 	// from the msg.InstanceUid field.

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opamp-go/client/internal/utils"
 	"github.com/open-telemetry/opamp-go/client/types"
 	sharedinternal "github.com/open-telemetry/opamp-go/internal"
 	"github.com/open-telemetry/opamp-go/internal/testhelpers"
@@ -25,7 +26,7 @@ import (
 
 func newTestHTTPSender() *HTTPSender {
 	sender := NewHTTPSender(&sharedinternal.NopLogger{})
-	sender.SetHTTPClient(&http.Client{})
+	sender.SetHTTPClient(utils.NewHttpClient())
 	return sender
 }
 

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -18,6 +18,10 @@ type StartSettings struct {
 	// Optional additional HTTP headers to send with all HTTP requests.
 	Header http.Header
 
+	// Optional HTTP client used by the plain HTTP transport for OpAMP requests.
+	// If nil, a default HTTP client will be used. WebSocket transport ignores this field.
+	Client *http.Client
+
 	// Optional function that can be used to modify the HTTP headers
 	// before each HTTP request.
 	// Can modify and return the argument or return the argument without modifying.

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -28,12 +28,18 @@ type StartSettings struct {
 	HeaderFunc func(http.Header) http.Header
 
 	// Optional TLS config for HTTP connection.
+	//
+	// Deprecated for HTTP transport: configure TLS on Client instead.
 	TLSConfig *tls.Config
 
 	// Optional Proxy configuration
 	// The ProxyURL may be http(s) or socks5; if no schema is specified http is assumed.
+	//
+	// Deprecated for HTTP transport: configure the proxy on Client instead.
 	ProxyURL string
 	// ProxyHeaders gives the headers an HTTP client will present on a proxy CONNECT request.
+	//
+	// Deprecated for HTTP transport: configure proxy headers on Client instead.
 	ProxyHeaders http.Header
 
 	// Agent information.

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -28,18 +28,12 @@ type StartSettings struct {
 	HeaderFunc func(http.Header) http.Header
 
 	// Optional TLS config for HTTP connection.
-	//
-	// Deprecated for HTTP transport: configure TLS on Client instead.
 	TLSConfig *tls.Config
 
 	// Optional Proxy configuration
 	// The ProxyURL may be http(s) or socks5; if no schema is specified http is assumed.
-	//
-	// Deprecated for HTTP transport: configure the proxy on Client instead.
 	ProxyURL string
 	// ProxyHeaders gives the headers an HTTP client will present on a proxy CONNECT request.
-	//
-	// Deprecated for HTTP transport: configure proxy headers on Client instead.
 	ProxyHeaders http.Header
 
 	// Agent information.


### PR DESCRIPTION
In https://github.com/open-telemetry/opamp-go/pull/560 it was proposed that HTTP client be added to StartSettings instead of adding any further individual HTTP client settings to there.

This is a draft for doing that, where I've made the minimal amount of changes to achieve that for now (also haven't added additional tests yet). There are several approaches that could be taken from here, but I'd like feedback on the following points before doing so:

* Should the specified client also be used for WebSocket?
* Should existing settings that the library user can apply to the client be removed, or kept for backwards compatibility/convenience?
* Would it make sense to create separate StartSettings types for WebSocket and HTTP request based client? (with common part for use by clientcommon)