### PR TITLE
Add Debug message for ServerToAgent and AgentToServer in the example server

### DIFF
--- a/internal/examples/server/opampsrv/opampsrv.go
+++ b/internal/examples/server/opampsrv/opampsrv.go
@@ -152,7 +152,7 @@ func formatAgentToServer(msg *protobufs.AgentToServer) string {
 			parts = append(parts, fmt.Sprintf("RemoteConfigStatusHash=%x", msg.RemoteConfigStatus.LastRemoteConfigHash))
 		}
 		if msg.RemoteConfigStatus.ErrorMessage != "" {
-			parts = append(parts, fmt.Sprintf("RemoteConfigStatusErrorMessage=%x", msg.RemoteConfigStatus.ErrorMessage))
+			parts = append(parts, fmt.Sprintf("RemoteConfigStatusErrorMessage=%q", msg.RemoteConfigStatus.ErrorMessage))
 		}
 	}
 	if msg.PackageStatuses != nil {
@@ -160,7 +160,7 @@ func formatAgentToServer(msg *protobufs.AgentToServer) string {
 			parts = append(parts, fmt.Sprintf("ServerProvidedAllPackagesHash=%x", msg.PackageStatuses.ServerProvidedAllPackagesHash))
 		}
 		if msg.PackageStatuses.ErrorMessage != "" {
-			parts = append(parts, fmt.Sprintf("PackageStatusesErrorMessage=%x", msg.PackageStatuses.ErrorMessage))
+			parts = append(parts, fmt.Sprintf("PackageStatusesErrorMessage=%q", msg.PackageStatuses.ErrorMessage))
 		}
 	}
 	if msg.AgentDisconnect != nil {
@@ -189,7 +189,7 @@ func formatAgentToServer(msg *protobufs.AgentToServer) string {
 			parts = append(parts, fmt.Sprintf("ConnectionSettingsStatusHash=%x", msg.ConnectionSettingsStatus.LastConnectionSettingsHash))
 		}
 		if msg.ConnectionSettingsStatus.ErrorMessage != "" {
-			parts = append(parts, fmt.Sprintf("ConnectionSettingsStatusErrorMessage=%x", msg.ConnectionSettingsStatus.ErrorMessage))
+			parts = append(parts, fmt.Sprintf("ConnectionSettingsStatusErrorMessage=%q", msg.ConnectionSettingsStatus.ErrorMessage))
 		}
 	}
 	return strings.Join(parts, ", ")

--- a/internal/examples/server/opampsrv/opampsrv.go
+++ b/internal/examples/server/opampsrv/opampsrv.go
@@ -2,9 +2,11 @@ package opampsrv
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -119,15 +121,130 @@ func (srv *Server) onMessage(ctx context.Context, conn types.Connection, msg *pr
 		return response
 	}
 
+	srv.logger.Debugf(ctx, "AgentToServer: InstanceUid=%x, %s", instanceId, formatAgentToServer(msg))
+
 	agent := srv.agents.FindOrCreateAgent(instanceId, conn)
 
 	// Process the status report and continue building the response.
 	agent.UpdateStatus(msg, response)
 
-	if msg.ConnectionSettingsStatus != nil {
-		srv.logger.Debugf(ctx, "Connection settings for instance %x %s (err=%s) hash=%x", instanceId, msg.ConnectionSettingsStatus.Status.String(), msg.ConnectionSettingsStatus.ErrorMessage, msg.ConnectionSettingsStatus.LastConnectionSettingsHash)
-	}
-
 	// Send the response back to the Agent.
+	srv.logger.Debugf(ctx, "ServerToAgent: InstanceUid=%x, %s", instanceId, formatServerToAgent(response))
 	return response
+}
+
+func formatAgentToServer(msg *protobufs.AgentToServer) string {
+	var parts []string
+	parts = append(parts, fmt.Sprintf("SequenceNum=%d", msg.SequenceNum))
+	if msg.AgentDescription != nil {
+		parts = append(parts, fmt.Sprintf("AgentDescription=%s", msg.AgentDescription))
+	}
+	parts = append(parts, fmt.Sprintf("Capabilities=[%s]", formatBitmask(msg.Capabilities, protobufs.AgentCapabilities_name, "AgentCapabilities_")))
+	if msg.Health != nil {
+		parts = append(parts, fmt.Sprintf("Healthy=%v", msg.Health.Healthy))
+	}
+	if msg.EffectiveConfig != nil && msg.EffectiveConfig.ConfigMap != nil {
+		parts = append(parts, fmt.Sprintf("EffectiveConfigFiles=%d", len(msg.EffectiveConfig.ConfigMap.ConfigMap)))
+	}
+	if msg.RemoteConfigStatus != nil {
+		parts = append(parts, fmt.Sprintf("RemoteConfigStatus=%s", strings.TrimPrefix(msg.RemoteConfigStatus.Status.String(), "RemoteConfigStatuses_")))
+		if len(msg.RemoteConfigStatus.LastRemoteConfigHash) > 0 {
+			parts = append(parts, fmt.Sprintf("RemoteConfigStatusHash=%x", msg.RemoteConfigStatus.LastRemoteConfigHash))
+		}
+		if msg.RemoteConfigStatus.ErrorMessage != "" {
+			parts = append(parts, fmt.Sprintf("RemoteConfigStatusErrorMessage=%x", msg.RemoteConfigStatus.ErrorMessage))
+		}
+	}
+	if msg.PackageStatuses != nil {
+		if len(msg.PackageStatuses.ServerProvidedAllPackagesHash) > 0 {
+			parts = append(parts, fmt.Sprintf("ServerProvidedAllPackagesHash=%x", msg.PackageStatuses.ServerProvidedAllPackagesHash))
+		}
+		if msg.PackageStatuses.ErrorMessage != "" {
+			parts = append(parts, fmt.Sprintf("PackageStatusesErrorMessage=%x", msg.PackageStatuses.ErrorMessage))
+		}
+	}
+	if msg.AgentDisconnect != nil {
+		parts = append(parts, "AgentDisconnect=<set>")
+	}
+	if msg.Flags != 0 {
+		parts = append(parts, fmt.Sprintf("Flags=[%s]", formatBitmask(msg.Flags, protobufs.AgentToServerFlags_name, "AgentToServerFlags_")))
+	}
+	if msg.ConnectionSettingsRequest != nil && msg.ConnectionSettingsRequest.Opamp != nil {
+		parts = append(parts, "ConnectionSettingsRequest=<set>")
+	}
+	if msg.CustomCapabilities != nil {
+		parts = append(parts, fmt.Sprintf("CustomCapabilities=%v", msg.CustomCapabilities.Capabilities))
+	}
+	if msg.CustomMessage != nil {
+		parts = append(parts, fmt.Sprintf("CustomMessage={Capability=%q, Type=%q}", msg.CustomMessage.GetCapability(), msg.CustomMessage.GetType()))
+	}
+	if msg.AvailableComponents != nil {
+		if len(msg.AvailableComponents.Hash) > 0 {
+			parts = append(parts, fmt.Sprintf("AvailableComponentsHash=%x", msg.AvailableComponents.Hash))
+		}
+	}
+	if msg.ConnectionSettingsStatus != nil {
+		parts = append(parts, fmt.Sprintf("ConnectionSettingsStatus=%s", strings.TrimPrefix(msg.ConnectionSettingsStatus.Status.String(), "ConnectionSettingsStatuses_")))
+		if len(msg.ConnectionSettingsStatus.LastConnectionSettingsHash) > 0 {
+			parts = append(parts, fmt.Sprintf("ConnectionSettingsStatusHash=%x", msg.ConnectionSettingsStatus.LastConnectionSettingsHash))
+		}
+		if msg.ConnectionSettingsStatus.ErrorMessage != "" {
+			parts = append(parts, fmt.Sprintf("ConnectionSettingsStatusErrorMessage=%x", msg.ConnectionSettingsStatus.ErrorMessage))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatServerToAgent(msg *protobufs.ServerToAgent) string {
+	var parts []string
+	if msg.ErrorResponse != nil {
+		parts = append(parts, fmt.Sprintf("ErrorResponse=%s", msg.ErrorResponse))
+	}
+	if msg.RemoteConfig != nil && len(msg.RemoteConfig.ConfigHash) > 0 {
+		parts = append(parts, fmt.Sprintf("RemoteConfigHash=%x", msg.RemoteConfig.ConfigHash))
+	}
+	if msg.ConnectionSettings != nil && len(msg.ConnectionSettings.Hash) > 0 {
+		parts = append(parts, fmt.Sprintf("ConnectionSettingsHash=%x", msg.ConnectionSettings.Hash))
+	}
+	if msg.PackagesAvailable != nil && len(msg.PackagesAvailable.AllPackagesHash) > 0 {
+		parts = append(parts, fmt.Sprintf("AllPackagesHash=%x", msg.PackagesAvailable.AllPackagesHash))
+	}
+	if msg.Flags != 0 {
+		parts = append(parts, fmt.Sprintf("Flags=[%s]", formatBitmask(msg.Flags, protobufs.ServerToAgentFlags_name, "ServerToAgentFlags_")))
+	}
+	if msg.Capabilities != 0 {
+		parts = append(parts, fmt.Sprintf("Capabilities=[%s]", formatBitmask(msg.Capabilities, protobufs.ServerCapabilities_name, "ServerCapabilities_")))
+	}
+	if msg.AgentIdentification != nil {
+		parts = append(parts, fmt.Sprintf("AgentIdentification=%s", msg.AgentIdentification))
+	}
+	if msg.Command != nil {
+		parts = append(parts, fmt.Sprintf("Command=%s", msg.Command))
+	}
+	if msg.CustomCapabilities != nil {
+		parts = append(parts, fmt.Sprintf("CustomCapabilities=%v", msg.CustomCapabilities.Capabilities))
+	}
+	if msg.CustomMessage != nil {
+		parts = append(parts, fmt.Sprintf("CustomMessage={Capability=%q, Type=%q}", msg.CustomMessage.GetCapability(), msg.CustomMessage.GetType()))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatBitmask(value uint64, nameMap map[int32]string, prefix string) string {
+	if value == 0 {
+		return strings.TrimPrefix(nameMap[0], prefix)
+	}
+	var names []string
+	remaining := value
+	for bit := uint64(1); remaining != 0; bit <<= 1 {
+		if value&bit != 0 {
+			if name, ok := nameMap[int32(bit)]; ok {
+				names = append(names, strings.TrimPrefix(name, prefix))
+			} else {
+				names = append(names, fmt.Sprintf("Unknown(0x%x)", bit))
+			}
+			remaining &^= bit
+		}
+	}
+	return strings.Join(names, "|")
 }

--- a/internal/examples/server/uisrv/ui.go
+++ b/internal/examples/server/uisrv/ui.go
@@ -284,7 +284,7 @@ func opampConnectionSettings(w http.ResponseWriter, r *http.Request) {
 
 	select {
 	case <-timer.C:
-		logger.Printf("Time out waiting for agent %s to reconnect\n", instanceId)
+		logger.Printf("Time out waiting for agent %x to reconnect\n", instanceId)
 	}
 
 	http.Redirect(w, r, "/agent?instanceid="+uid.String(), http.StatusSeeOther)

--- a/internal/examples/server/uisrv/ui.go
+++ b/internal/examples/server/uisrv/ui.go
@@ -196,7 +196,7 @@ func rotateInstanceClientCert(w http.ResponseWriter, r *http.Request) {
 	// Send the offer to the agent.
 	data.AllAgents.OfferAgentConnectionSettings(instanceId, offers)
 
-	logger.Printf("Waiting for agent %s to reconnect\n", instanceId)
+	logger.Printf("Waiting for agent %x to reconnect\n", instanceId)
 
 	// Wait for up to 5 seconds for a Status update, which is expected
 	// to be reported by the agent after we set the remote config.
@@ -274,7 +274,7 @@ func opampConnectionSettings(w http.ResponseWriter, r *http.Request) {
 
 	data.AllAgents.OfferAgentConnectionSettings(instanceId, offers)
 
-	logger.Printf("Waiting for agent %s to reconnect\n", instanceId)
+	logger.Printf("Waiting for agent %x to reconnect\n", instanceId)
 
 	// Wait for up to 5 seconds for a Status update, which is expected
 	// to be reported by the agent after we set the remote config.

--- a/internal/examples/server/uisrv/ui.go
+++ b/internal/examples/server/uisrv/ui.go
@@ -206,7 +206,7 @@ func rotateInstanceClientCert(w http.ResponseWriter, r *http.Request) {
 
 	select {
 	case <-timer.C:
-		logger.Printf("Time out waiting for agent %s to reconnect\n", instanceId)
+		logger.Printf("Time out waiting for agent %x to reconnect\n", instanceId)
 	}
 
 	http.Redirect(w, r, "/agent?instanceid="+uid.String(), http.StatusSeeOther)

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -301,7 +301,6 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 			continue
 		}
 
-		s.logger.Debugf(msgContext, "AgentToServer message: %v", &request)
 		response := connectionCallbacks.OnMessage(msgContext, agentConn, &request)
 		if response == nil { // No send message when 'response' is empty
 			continue
@@ -324,7 +323,6 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 			connectionCallbacks.OnMessageResponseError(agentConn, response, err)
 			break
 		}
-		s.logger.Debugf(msgContext, "ServerToAgent message: %v", response)
 	}
 }
 

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -301,6 +301,7 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 			continue
 		}
 
+		s.logger.Debugf(msgContext, "AgentToServer message: %v", &request)
 		response := connectionCallbacks.OnMessage(msgContext, agentConn, &request)
 		if response == nil { // No send message when 'response' is empty
 			continue
@@ -323,6 +324,7 @@ func (s *server) handleWSConnection(reqCtx context.Context, wsConn *websocket.Co
 			connectionCallbacks.OnMessageResponseError(agentConn, response, err)
 			break
 		}
+		s.logger.Debugf(msgContext, "ServerToAgent message: %v", response)
 	}
 }
 


### PR DESCRIPTION
By adding debug logs it helps better understanding the message flow between the Agent and Server and can help troubleshoot messages like Heartbeat.

Example:
`
2026/06/03 14:08:13.631624 [OPAMP] AgentToServer: InstanceUid=019e8d6253bc72518cba4c2cd8e52939, SequenceNum=0, AgentDescription=identifying_attributes:{key:"service.name"  value:{string_value:"io.opentelemetry.collector"}}  identifying_attributes:{key:"service.version"  value:{string_value:"1.0.0"}}  non_identifying_attributes:{key:"os.type"  value:{string_value:"darwin"}}  non_identifying_attributes:{key:"host.name"  value:{string_value:"Y6N9N4DJGH"}}, Capabilities=[ReportsStatus|AcceptsRemoteConfig|ReportsEffectiveConfig|ReportsOwnMetrics|AcceptsOpAMPConnectionSettings|ReportsRemoteConfig|ReportsConnectionSettingsStatus], EffectiveConfigFiles=1, RemoteConfigStatus=UNSET, ConnectionSettingsRequest=<set>, CustomCapabilities=[io.opentelemetry.custom.health]
2026/06/03 14:08:13.638849 [OPAMP] ServerToAgent: InstanceUid=019e8d6253bc72518cba4c2cd8e52939, RemoteConfigHash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, ConnectionSettingsHash=c982ecb3783aad27fcd48cd383816d6d2e218d2830f670ea09725f3d0019bc81
`