### PR TITLE
examples: Add `ConfigCalculator` interface and example

### DIFF
--- a/internal/examples/agent/agent/agent.go
+++ b/internal/examples/agent/agent/agent.go
@@ -60,9 +60,10 @@ type Agent struct {
 	client client.OpAMPClient
 	logger types.Logger
 
-	agentType    string
-	agentVersion string
-	instanceId   uuid.UUID
+	agentType       string
+	agentVersion    string
+	instanceId      uuid.UUID
+	extraAttributes map[string]string
 
 	agentConfig *config.AgentConfig
 
@@ -128,6 +129,13 @@ func WithAgentVersion(s string) Option {
 func WithInstanceID(id uuid.UUID) Option {
 	return func(agent *Agent) {
 		agent.instanceId = id
+	}
+}
+
+// WithExtraAttributes sets additional non-identifying attributes reported by the agent.
+func WithExtraAttributes(attrs map[string]string) Option {
+	return func(agent *Agent) {
+		agent.extraAttributes = attrs
 	}
 }
 
@@ -319,6 +327,29 @@ func (agent *Agent) createAgentIdentity() {
 				},
 			},
 		},
+	}
+	if len(agent.extraAttributes) > 0 {
+		keys := make([]string, 0, len(agent.extraAttributes))
+		for key := range agent.extraAttributes {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		extraAttrs := make([]*protobufs.KeyValue, 0, len(keys))
+		for _, key := range keys {
+			extraAttrs = append(extraAttrs, &protobufs.KeyValue{
+				Key: key,
+				Value: &protobufs.AnyValue{
+					Value: &protobufs.AnyValue_StringValue{
+						StringValue: agent.extraAttributes[key],
+					},
+				},
+			})
+		}
+		agent.agentDescription.NonIdentifyingAttributes = append(
+			agent.agentDescription.NonIdentifyingAttributes,
+			extraAttrs...,
+		)
 	}
 }
 

--- a/internal/examples/agent/main.go
+++ b/internal/examples/agent/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"time"
 
 	opampinternal "github.com/open-telemetry/opamp-go/internal"
@@ -39,6 +40,7 @@ type flagConfig struct {
 	endpoint              string
 	heartbeat             time.Duration
 	quietAgent            bool
+	extraAttributes       map[string]string
 	// scaleCount = 1 runs a normal agent
 	// scaleCount > 1 runs scale test agents (pre-assigned IDs, no initial cert request)
 	scaleCount uint64
@@ -98,7 +100,7 @@ func (cfg flagConfig) verifyArgs() error {
 
 // loadEnv will attempt to load config options from environment variables.
 // used to specifiy options when running the agent in a container.
-func loadEnv(cfg *flagConfig) {
+func loadEnv(cfg *flagConfig) error {
 	if s, ok := os.LookupEnv("AGENT_TYPE"); ok {
 		cfg.agentType = s
 	}
@@ -151,16 +153,46 @@ func loadEnv(cfg *flagConfig) {
 		}
 	}
 
+	if s, ok := os.LookupEnv("AGENT_EXTRA_ATTRIBUTES"); ok {
+		for _, attr := range strings.Split(s, ",") {
+			if err := addExtraAttribute(cfg.extraAttributes, attr); err != nil {
+				return err
+			}
+		}
+	}
+
 	if s, ok := os.LookupEnv("AGENT_SCALE_COUNT"); ok {
 		count, err := strconv.ParseUint(s, 10, 64)
 		if err == nil {
 			cfg.scaleCount = count
 		}
 	}
+	return nil
+}
+
+func addExtraAttribute(attrs map[string]string, raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	key, value, ok := strings.Cut(raw, "=")
+	if !ok {
+		return fmt.Errorf("extra attribute %q must use key=value format", raw)
+	}
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" {
+		return fmt.Errorf("extra attribute %q has an empty key", raw)
+	}
+	attrs[key] = value
+	return nil
 }
 
 func main() {
-	var cfg flagConfig
+	cfg := flagConfig{
+		extraAttributes: map[string]string{},
+	}
 	flag.StringVar(&cfg.agentType, "t", "io.opentelemetry.collector", "Agent Type String (env var: AGENT_TYPE).")
 	flag.StringVar(&cfg.agentVersion, "v", "1.0.0", "Agent Version String (env var: AGENT_VERSION).")
 	flag.BoolVar(&cfg.tlsInsecure, "tls-insecure", false, "Disable the client transport security (env var: AGENT_TLS_INSECURE).")
@@ -171,12 +203,17 @@ func main() {
 	flag.StringVar(&cfg.endpoint, "endpoint", "wss://127.0.0.1:4320/v1/opamp", "OpAMP server endpoint URL (env var: AGENT_ENDPOINT).")
 	flag.DurationVar(&cfg.heartbeat, "heartbeat", time.Second*30, "Heartbeat duration (env var: AGENT_HEARTBEAT).")
 	flag.BoolVar(&cfg.quietAgent, "quite-agent", false, "Disable agent logger (env var: AGENT_QUIET).")
+	flag.Func("extra-attribute", "Additional non-identifying AgentDescription attribute in key=value format. May be specified multiple times (env var: AGENT_EXTRA_ATTRIBUTES).", func(value string) error {
+		return addExtraAttribute(cfg.extraAttributes, value)
+	})
 	flag.Uint64Var(&cfg.scaleCount, "scale-count", 1, "The number of agents to start in scale mode (env var: AGENT_SCALE_COUNT).")
 
 	flag.Parse()
-	loadEnv(&cfg)
 
 	logger := log.Default()
+	if err := loadEnv(&cfg); err != nil {
+		logger.Fatalf("Env verification error: %v", err)
+	}
 	if err := cfg.verifyArgs(); err != nil {
 		logger.Fatalf("Arg verification error: %v", err)
 	}
@@ -238,6 +275,7 @@ func runScale(ctx context.Context, cfg flagConfig) ([]*agent.Agent, error) {
 		opts := []agent.Option{
 			agent.WithAgentType(cfg.agentType),
 			agent.WithAgentVersion(cfg.agentVersion),
+			agent.WithExtraAttributes(cfg.extraAttributes),
 		}
 		if cfg.quietAgent {
 			opts = append(opts, agent.WithLogger(nopLogger))

--- a/internal/examples/agent/main_test.go
+++ b/internal/examples/agent/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddExtraAttribute(t *testing.T) {
+	attrs := map[string]string{}
+
+	require.NoError(t, addExtraAttribute(attrs, " prometheus.cluster = demo "))
+
+	assert.Equal(t, map[string]string{"prometheus.cluster": "demo"}, attrs)
+}
+
+func TestAddExtraAttributeRejectsInvalidFormat(t *testing.T) {
+	err := addExtraAttribute(map[string]string{}, "prometheus.cluster")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key=value")
+}
+
+func TestLoadEnvExtraAttributes(t *testing.T) {
+	t.Setenv("AGENT_EXTRA_ATTRIBUTES", "prometheus.cluster=demo,team=collector")
+
+	cfg := flagConfig{
+		extraAttributes: map[string]string{},
+	}
+
+	require.NoError(t, loadEnv(&cfg))
+
+	assert.Equal(t, map[string]string{
+		"prometheus.cluster": "demo",
+		"team":               "collector",
+	}, cfg.extraAttributes)
+}

--- a/internal/examples/server/data/agent.go
+++ b/internal/examples/server/data/agent.go
@@ -34,6 +34,8 @@ type Agent struct {
 	// Connection to the Agent.
 	conn types.Connection
 
+	configCalculators []ConfigCalculator
+
 	// mutex for the fields that follow it.
 	mux sync.RWMutex
 
@@ -69,7 +71,11 @@ func NewAgent(
 	instanceId InstanceId,
 	conn types.Connection,
 ) *Agent {
-	agent := &Agent{InstanceId: instanceId, InstanceIdStr: uuid.UUID(instanceId).String(), conn: conn}
+	agent := &Agent{
+		InstanceId:    instanceId,
+		InstanceIdStr: uuid.UUID(instanceId).String(),
+		conn:          conn,
+	}
 	tslConn, ok := conn.Connection().(*tls.Conn)
 	if ok {
 		// Client is using TLS connection.
@@ -83,6 +89,11 @@ func NewAgent(
 		}
 	}
 
+	return agent
+}
+
+func (agent *Agent) WithConfigCalculator(calculator ConfigCalculator) *Agent {
+	agent.configCalculators = append(agent.configCalculators, calculator)
 	return agent
 }
 
@@ -264,6 +275,26 @@ func (agent *Agent) hasCapability(capability protobufs.AgentCapabilities) bool {
 	return agent.Status.Capabilities&uint64(capability) != 0
 }
 
+func (agent *Agent) HasCapability(capability protobufs.AgentCapabilities) bool {
+	agent.mux.RLock()
+	defer agent.mux.RUnlock()
+
+	if agent.Status == nil {
+		return false
+	}
+	return agent.hasCapability(capability)
+}
+
+func (agent *Agent) AgentDescription() *protobufs.AgentDescription {
+	agent.mux.RLock()
+	defer agent.mux.RUnlock()
+
+	if agent.Status == nil || agent.Status.AgentDescription == nil {
+		return nil
+	}
+	return proto.Clone(agent.Status.AgentDescription).(*protobufs.AgentDescription)
+}
+
 func (agent *Agent) processStatusUpdate(
 	newStatus *protobufs.AgentToServer,
 	response *protobufs.ServerToAgent,
@@ -381,10 +412,15 @@ func (agent *Agent) calcRemoteConfig() bool {
 		},
 	}
 
+	configBody := agent.CustomInstanceConfig
+	for _, calculator := range agent.configCalculators {
+		configBody = calculator.Calculate(agent, configBody)
+	}
+
 	// Add the custom config for this particular Agent instance. Use empty
 	// string as the config file name.
 	cfg.Config.ConfigMap[""] = &protobufs.AgentConfigFile{
-		Body: []byte(agent.CustomInstanceConfig),
+		Body: []byte(configBody),
 	}
 
 	// Calculate the hash.
@@ -401,6 +437,19 @@ func (agent *Agent) calcRemoteConfig() bool {
 	agent.remoteConfig = &cfg
 
 	return configChanged
+}
+
+func (agent *Agent) RecalculateRemoteConfig() (*protobufs.AgentRemoteConfig, bool) {
+	agent.mux.Lock()
+	defer agent.mux.Unlock()
+
+	if agent.Status == nil || !agent.hasCapability(protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig) {
+		return nil, false
+	}
+	if !agent.calcRemoteConfig() {
+		return nil, false
+	}
+	return proto.Clone(agent.remoteConfig).(*protobufs.AgentRemoteConfig), true
 }
 
 func isEqualRemoteConfig(c1, c2 *protobufs.AgentRemoteConfig) bool {
@@ -442,7 +491,7 @@ func isEqualConfigFile(f1, f2 *protobufs.AgentConfigFile) bool {
 	if f1 == nil || f2 == nil {
 		return false
 	}
-	return bytes.Compare(f1.Body, f2.Body) == 0 && f1.ContentType == f2.ContentType
+	return bytes.Equal(f1.Body, f2.Body) && f1.ContentType == f2.ContentType
 }
 
 func (agent *Agent) calcConnectionSettings(response *protobufs.ServerToAgent) {
@@ -515,7 +564,7 @@ func (agent *Agent) processConnectionSettingsRequest(
 		return
 	}
 
-	if csr.CheckSignature() != err {
+	if err := csr.CheckSignature(); err != nil {
 		agent.addErrorResponse("Certificate request signature check failed: "+err.Error(), response)
 		return
 	}

--- a/internal/examples/server/data/agents.go
+++ b/internal/examples/server/data/agents.go
@@ -12,9 +12,10 @@ import (
 )
 
 type Agents struct {
-	mux         sync.RWMutex
-	agentsById  map[InstanceId]*Agent
-	connections map[types.Connection]map[InstanceId]bool
+	mux               sync.RWMutex
+	agentsById        map[InstanceId]*Agent
+	connections       map[types.Connection]map[InstanceId]bool
+	configCalculators []ConfigCalculator
 }
 
 var logger = log.New(log.Default().Writer(), "[AGENTS] ", log.Default().Flags()|log.Lmsgprefix|log.Lmicroseconds)
@@ -23,12 +24,13 @@ var logger = log.New(log.Default().Writer(), "[AGENTS] ", log.Default().Flags()|
 // connection.
 func (agents *Agents) RemoveConnection(conn types.Connection) {
 	agents.mux.Lock()
-	defer agents.mux.Unlock()
-
 	for instanceId := range agents.connections[conn] {
 		delete(agents.agentsById, instanceId)
 	}
 	delete(agents.connections, conn)
+	agents.mux.Unlock()
+
+	agents.AgentsChanged(nil, nil)
 }
 
 func (agents *Agents) SendCustomMessageToAgent(
@@ -50,6 +52,61 @@ func (agents *Agents) SetCustomConfigForAgent(
 	if agent != nil {
 		agent.SetCustomConfig(config, notifyNextStatusUpdate)
 	}
+}
+
+func (agents *Agents) AgentsChanged(
+	currentAgent *Agent,
+	currentResponse *protobufs.ServerToAgent,
+) {
+	allAgents := agents.getAllAgents()
+
+	changedAgents := map[InstanceId]bool{}
+	for _, calculator := range agents.configCalculators {
+		for instanceID := range calculator.AgentsChanged(allAgents) {
+			changedAgents[instanceID] = true
+		}
+	}
+
+	agents.recalculateRemoteConfigs(changedAgents, allAgents, currentAgent, currentResponse)
+}
+
+func (agents *Agents) recalculateRemoteConfigs(
+	changedAgents map[InstanceId]bool,
+	allAgents map[InstanceId]*Agent,
+	currentAgent *Agent,
+	currentResponse *protobufs.ServerToAgent,
+) {
+	var updates []remoteConfigUpdate
+	for instanceID := range changedAgents {
+		agent := allAgents[instanceID]
+		if agent == nil {
+			continue
+		}
+
+		remoteConfig, changed := agent.RecalculateRemoteConfig()
+		if !changed {
+			continue
+		}
+		if agent == currentAgent && currentResponse != nil {
+			currentResponse.RemoteConfig = remoteConfig
+			continue
+		}
+		updates = append(updates, remoteConfigUpdate{
+			agent:        agent,
+			remoteConfig: remoteConfig,
+		})
+	}
+
+	for _, update := range updates {
+		update.agent.SendToAgent(&protobufs.ServerToAgent{
+			RemoteConfig: update.remoteConfig,
+		})
+	}
+}
+
+type remoteConfigUpdate struct {
+	agent        *Agent
+	remoteConfig *protobufs.AgentRemoteConfig
 }
 
 func isEqualAgentDescr(d1, d2 *protobufs.AgentDescription) bool {
@@ -90,6 +147,9 @@ func (agents *Agents) FindOrCreateAgent(agentId InstanceId, conn types.Connectio
 	agent := agents.agentsById[agentId]
 	if agent == nil {
 		agent = NewAgent(agentId, conn)
+		for _, calculator := range agents.configCalculators {
+			agent.WithConfigCalculator(calculator)
+		}
 		agents.agentsById[agentId] = agent
 
 		// Ensure the Agent's instance id is associated with the connection.
@@ -113,19 +173,23 @@ func (agents *Agents) GetAgentReadonlyClone(agentId InstanceId) *Agent {
 }
 
 func (agents *Agents) GetAllAgentsReadonlyClone() map[InstanceId]*Agent {
-	agents.mux.RLock()
-
-	// Clone the map first
-	m := map[InstanceId]*Agent{}
-	for id, agent := range agents.agentsById {
-		m[id] = agent
-	}
-	agents.mux.RUnlock()
+	m := agents.getAllAgents()
 
 	// Clone agents in the map
 	for id, agent := range m {
 		// Return a clone to allow safe access after returning.
 		m[id] = agent.CloneReadonly()
+	}
+	return m
+}
+
+func (agents *Agents) getAllAgents() map[InstanceId]*Agent {
+	agents.mux.RLock()
+	defer agents.mux.RUnlock()
+
+	m := map[InstanceId]*Agent{}
+	for id, agent := range agents.agentsById {
+		m[id] = agent
 	}
 	return m
 }
@@ -150,10 +214,15 @@ func (a *Agents) OfferAgentConnectionSettings(
 	}
 }
 
-var AllAgents = Agents{
-	agentsById:  map[InstanceId]*Agent{},
-	connections: map[types.Connection]map[InstanceId]bool{},
+func NewAgents(configCalculators ...ConfigCalculator) *Agents {
+	return &Agents{
+		agentsById:        map[InstanceId]*Agent{},
+		connections:       map[types.Connection]map[InstanceId]bool{},
+		configCalculators: configCalculators,
+	}
 }
+
+var AllAgents = NewAgents()
 
 // toHash computes a sha256 hash from fields within ConnectionSettingsOffers
 func toHash(c *protobufs.ConnectionSettingsOffers) []byte {

--- a/internal/examples/server/data/config_calculator.go
+++ b/internal/examples/server/data/config_calculator.go
@@ -1,0 +1,6 @@
+package data
+
+type ConfigCalculator interface {
+	Calculate(agent *Agent, configBody string) string
+	AgentsChanged(agents map[InstanceId]*Agent) map[InstanceId]bool
+}

--- a/internal/examples/server/data/config_calculator_test.go
+++ b/internal/examples/server/data/config_calculator_test.go
@@ -1,0 +1,33 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalcRemoteConfigAppliesCalculatorsInOrder(t *testing.T) {
+	agent := NewAgent(
+		InstanceId{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		&recordingConnection{},
+	)
+	agent.WithConfigCalculator(appendCalculator(" first"))
+	agent.WithConfigCalculator(appendCalculator(" second"))
+	agent.CustomInstanceConfig = "base"
+
+	changed := agent.calcRemoteConfig()
+
+	require.True(t, changed)
+	assert.Equal(t, "base first second", string(agent.remoteConfig.Config.ConfigMap[""].Body))
+}
+
+type appendCalculator string
+
+func (calculator appendCalculator) Calculate(_ *Agent, configBody string) string {
+	return configBody + string(calculator)
+}
+
+func (calculator appendCalculator) AgentsChanged(_ map[InstanceId]*Agent) map[InstanceId]bool {
+	return nil
+}

--- a/internal/examples/server/data/prometheus_sharding.go
+++ b/internal/examples/server/data/prometheus_sharding.go
@@ -1,0 +1,338 @@
+package data
+
+import (
+	"bytes"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+const (
+	prometheusClusterAttribute = "prometheus.cluster"
+	prometheusShardTargetLabel = "__tmp_opamp_shard"
+)
+
+type prometheusShardAssignment struct {
+	ClusterName string
+	ShardIndex  int
+	ShardCount  int
+}
+
+type PrometheusShardingCalculator struct {
+	mux         sync.RWMutex
+	assignments map[InstanceId]prometheusShardAssignment
+}
+
+func NewPrometheusShardingCalculator() *PrometheusShardingCalculator {
+	return &PrometheusShardingCalculator{
+		assignments: map[InstanceId]prometheusShardAssignment{},
+	}
+}
+
+func (calculator *PrometheusShardingCalculator) Calculate(agent *Agent, configBody string) string {
+	calculator.mux.RLock()
+	assignment, ok := calculator.assignments[agent.InstanceId]
+	calculator.mux.RUnlock()
+	if !ok {
+		return configBody
+	}
+
+	shardedConfig, changed := applyPrometheusSharding(configBody, &assignment)
+	if !changed {
+		return configBody
+	}
+	return shardedConfig
+}
+
+func (calculator *PrometheusShardingCalculator) AgentsChanged(
+	agents map[InstanceId]*Agent,
+) map[InstanceId]bool {
+	clustersByAgent := map[InstanceId]string{}
+	for instanceID, agent := range agents {
+		clusterName, ok := prometheusClusterName(agent)
+		if ok {
+			clustersByAgent[instanceID] = clusterName
+		}
+	}
+
+	nextAssignments := calculatePrometheusShardAssignments(clustersByAgent)
+
+	calculator.mux.Lock()
+	defer calculator.mux.Unlock()
+
+	changedAgents := map[InstanceId]bool{}
+	for instanceID, nextAssignment := range nextAssignments {
+		prevAssignment, ok := calculator.assignments[instanceID]
+		if !ok || prevAssignment != nextAssignment {
+			changedAgents[instanceID] = true
+		}
+	}
+	for instanceID := range calculator.assignments {
+		if _, stillAssigned := nextAssignments[instanceID]; stillAssigned {
+			continue
+		}
+		if _, stillConnected := agents[instanceID]; stillConnected {
+			changedAgents[instanceID] = true
+		}
+	}
+
+	calculator.assignments = nextAssignments
+	return changedAgents
+}
+
+func prometheusClusterName(agent *Agent) (string, bool) {
+	if !agent.HasCapability(protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig) {
+		return "", false
+	}
+	return prometheusClusterNameFromDescription(agent.AgentDescription())
+}
+
+func prometheusClusterNameFromDescription(description *protobufs.AgentDescription) (string, bool) {
+	if description == nil {
+		return "", false
+	}
+
+	for _, attrs := range [][]*protobufs.KeyValue{
+		description.IdentifyingAttributes,
+		description.NonIdentifyingAttributes,
+	} {
+		for _, attr := range attrs {
+			if attr.GetKey() != prometheusClusterAttribute {
+				continue
+			}
+			value := strings.TrimSpace(attr.GetValue().GetStringValue())
+			if value == "" {
+				return "", false
+			}
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func calculatePrometheusShardAssignments(clustersByAgent map[InstanceId]string) map[InstanceId]prometheusShardAssignment {
+	agentsByCluster := map[string][]InstanceId{}
+	for instanceID, clusterName := range clustersByAgent {
+		agentsByCluster[clusterName] = append(agentsByCluster[clusterName], instanceID)
+	}
+
+	assignments := map[InstanceId]prometheusShardAssignment{}
+	for clusterName, instanceIDs := range agentsByCluster {
+		sort.Slice(instanceIDs, func(i, j int) bool {
+			return bytes.Compare(instanceIDs[i][:], instanceIDs[j][:]) < 0
+		})
+		for shardIndex, instanceID := range instanceIDs {
+			assignments[instanceID] = prometheusShardAssignment{
+				ClusterName: clusterName,
+				ShardIndex:  shardIndex,
+				ShardCount:  len(instanceIDs),
+			}
+		}
+	}
+	return assignments
+}
+
+func applyPrometheusSharding(config string, assignment *prometheusShardAssignment) (string, bool) {
+	if assignment == nil || assignment.ShardCount <= 0 || assignment.ShardIndex < 0 {
+		return config, false
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(config), &root); err != nil {
+		return config, false
+	}
+	if len(root.Content) == 0 {
+		return config, false
+	}
+
+	changed := applyPrometheusShardingToDocument(root.Content[0], assignment)
+	if !changed {
+		return config, false
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&root); err != nil {
+		return config, false
+	}
+	if err := encoder.Close(); err != nil {
+		return config, false
+	}
+	return buf.String(), true
+}
+
+func applyPrometheusShardingToDocument(document *yaml.Node, assignment *prometheusShardAssignment) bool {
+	receivers, ok := mappingValue(document, "receivers")
+	if !ok || receivers.Kind != yaml.MappingNode {
+		return false
+	}
+
+	changed := false
+	for i := 0; i < len(receivers.Content); i += 2 {
+		receiverName := receivers.Content[i].Value
+		if !isPrometheusReceiverName(receiverName) {
+			continue
+		}
+		if applyPrometheusShardingToReceiver(receivers.Content[i+1], assignment) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func isPrometheusReceiverName(name string) bool {
+	return name == "prometheus" || strings.HasPrefix(name, "prometheus/")
+}
+
+func applyPrometheusShardingToReceiver(receiver *yaml.Node, assignment *prometheusShardAssignment) bool {
+	if receiver.Kind != yaml.MappingNode {
+		return false
+	}
+
+	receiverConfig, ok := mappingValue(receiver, "config")
+	if !ok || receiverConfig.Kind != yaml.MappingNode {
+		return false
+	}
+
+	scrapeConfigs, ok := mappingValue(receiverConfig, "scrape_configs")
+	if !ok || scrapeConfigs.Kind != yaml.SequenceNode {
+		return false
+	}
+
+	changed := false
+	for _, scrapeConfig := range scrapeConfigs.Content {
+		if applyPrometheusShardingToScrapeConfig(scrapeConfig, assignment) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+func applyPrometheusShardingToScrapeConfig(scrapeConfig *yaml.Node, assignment *prometheusShardAssignment) bool {
+	if scrapeConfig.Kind != yaml.MappingNode {
+		return false
+	}
+
+	relabelConfigs, ok := mappingValue(scrapeConfig, "relabel_configs")
+	if ok && relabelConfigs.Kind != yaml.SequenceNode {
+		return false
+	}
+
+	if !ok {
+		relabelConfigs = &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		scrapeConfig.Content = append(
+			scrapeConfig.Content,
+			stringNode("relabel_configs"),
+			relabelConfigs,
+		)
+	}
+
+	desiredRelabelConfigs := &yaml.Node{
+		Kind: yaml.SequenceNode,
+		Tag:  "!!seq",
+	}
+	for _, relabelConfig := range relabelConfigs.Content {
+		if isPrometheusShardRelabelConfig(relabelConfig) {
+			continue
+		}
+		desiredRelabelConfigs.Content = append(desiredRelabelConfigs.Content, relabelConfig)
+	}
+	desiredRelabelConfigs.Content = append(
+		desiredRelabelConfigs.Content,
+		prometheusHashmodRelabelConfig(assignment),
+		prometheusKeepRelabelConfig(assignment),
+	)
+
+	if yamlNodesEqual(relabelConfigs, desiredRelabelConfigs) {
+		return false
+	}
+	relabelConfigs.Content = desiredRelabelConfigs.Content
+	return true
+}
+
+func isPrometheusShardRelabelConfig(relabelConfig *yaml.Node) bool {
+	if relabelConfig.Kind != yaml.MappingNode {
+		return false
+	}
+
+	if targetLabel, ok := mappingValue(relabelConfig, "target_label"); ok &&
+		targetLabel.Value == prometheusShardTargetLabel {
+		return true
+	}
+
+	sourceLabels, ok := mappingValue(relabelConfig, "source_labels")
+	if !ok || sourceLabels.Kind != yaml.SequenceNode {
+		return false
+	}
+	for _, sourceLabel := range sourceLabels.Content {
+		if sourceLabel.Value == prometheusShardTargetLabel {
+			return true
+		}
+	}
+	return false
+}
+
+func prometheusHashmodRelabelConfig(assignment *prometheusShardAssignment) *yaml.Node {
+	return mappingNode(
+		"source_labels", stringSequenceNode("__address__"),
+		"modulus", intNode(assignment.ShardCount),
+		"target_label", stringNode(prometheusShardTargetLabel),
+		"action", stringNode("hashmod"),
+	)
+}
+
+func prometheusKeepRelabelConfig(assignment *prometheusShardAssignment) *yaml.Node {
+	return mappingNode(
+		"source_labels", stringSequenceNode(prometheusShardTargetLabel),
+		"regex", stringNode(strconv.Itoa(assignment.ShardIndex)),
+		"action", stringNode("keep"),
+	)
+}
+
+func mappingValue(node *yaml.Node, key string) (*yaml.Node, bool) {
+	if node.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1], true
+		}
+	}
+	return nil, false
+}
+
+func mappingNode(items ...any) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	for i := 0; i < len(items); i += 2 {
+		node.Content = append(node.Content, stringNode(items[i].(string)), items[i+1].(*yaml.Node))
+	}
+	return node
+}
+
+func stringNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}
+
+func intNode(value int) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.Itoa(value)}
+}
+
+func stringSequenceNode(values ...string) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Style: yaml.FlowStyle}
+	for _, value := range values {
+		node.Content = append(node.Content, stringNode(value))
+	}
+	return node
+}
+
+func yamlNodesEqual(a, b *yaml.Node) bool {
+	aBytes, aErr := yaml.Marshal(a)
+	bBytes, bErr := yaml.Marshal(b)
+	return aErr == nil && bErr == nil && bytes.Equal(aBytes, bBytes)
+}

--- a/internal/examples/server/data/prometheus_sharding_test.go
+++ b/internal/examples/server/data/prometheus_sharding_test.go
@@ -1,0 +1,306 @@
+package data
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+func TestPrometheusClusterNameFromDescription(t *testing.T) {
+	tests := []struct {
+		name        string
+		description *protobufs.AgentDescription
+		want        string
+		wantOK      bool
+	}{
+		{
+			name: "identifying attribute",
+			description: &protobufs.AgentDescription{
+				IdentifyingAttributes: []*protobufs.KeyValue{
+					stringAttribute("prometheus.cluster", "prod"),
+				},
+			},
+			want:   "prod",
+			wantOK: true,
+		},
+		{
+			name: "non-identifying attribute",
+			description: &protobufs.AgentDescription{
+				NonIdentifyingAttributes: []*protobufs.KeyValue{
+					stringAttribute("prometheus.cluster", "staging"),
+				},
+			},
+			want:   "staging",
+			wantOK: true,
+		},
+		{
+			name: "empty attribute value",
+			description: &protobufs.AgentDescription{
+				IdentifyingAttributes: []*protobufs.KeyValue{
+					stringAttribute("prometheus.cluster", ""),
+				},
+			},
+			wantOK: false,
+		},
+		{
+			name: "missing attribute",
+			description: &protobufs.AgentDescription{
+				IdentifyingAttributes: []*protobufs.KeyValue{
+					stringAttribute("service.name", "otelcol"),
+				},
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := prometheusClusterNameFromDescription(tt.description)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCalculatePrometheusShardAssignments(t *testing.T) {
+	first := InstanceId{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	second := InstanceId{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+	third := InstanceId{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}
+	otherCluster := InstanceId{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
+
+	assignments := calculatePrometheusShardAssignments(map[InstanceId]string{
+		third:        "prod",
+		first:        "prod",
+		second:       "prod",
+		otherCluster: "staging",
+	})
+
+	require.Len(t, assignments, 4)
+	assert.Equal(t, prometheusShardAssignment{ClusterName: "prod", ShardIndex: 0, ShardCount: 3}, assignments[first])
+	assert.Equal(t, prometheusShardAssignment{ClusterName: "prod", ShardIndex: 1, ShardCount: 3}, assignments[second])
+	assert.Equal(t, prometheusShardAssignment{ClusterName: "prod", ShardIndex: 2, ShardCount: 3}, assignments[third])
+	assert.Equal(t, prometheusShardAssignment{ClusterName: "staging", ShardIndex: 0, ShardCount: 1}, assignments[otherCluster])
+}
+
+func TestApplyPrometheusSharding(t *testing.T) {
+	const config = `
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: my-job
+          static_configs:
+            - targets:
+                - app-1:9100
+                - app-2:9100
+          relabel_configs:
+            - source_labels: [job]
+              target_label: existing_label
+              action: replace
+            - source_labels: [__address__]
+              modulus: 99
+              target_label: __tmp_opamp_shard
+              action: hashmod
+            - source_labels: [__tmp_opamp_shard]
+              regex: "99"
+              action: keep
+  prometheus/secondary:
+    config:
+      scrape_configs:
+        - job_name: secondary
+`
+
+	assignment := &prometheusShardAssignment{
+		ClusterName: "prod",
+		ShardIndex:  1,
+		ShardCount:  3,
+	}
+
+	got, changed := applyPrometheusSharding(config, assignment)
+	require.True(t, changed)
+
+	again, changedAgain := applyPrometheusSharding(got, assignment)
+	assert.False(t, changedAgain)
+	assert.Equal(t, got, again)
+
+	primaryRelabels := scrapeRelabelConfigs(t, got, "prometheus", 0)
+	require.Len(t, primaryRelabels, 3)
+	assert.Equal(t, "existing_label", primaryRelabels[0]["target_label"])
+	assertPrometheusShardRelabels(t, primaryRelabels[1:], 3, "1")
+
+	secondaryRelabels := scrapeRelabelConfigs(t, got, "prometheus/secondary", 0)
+	require.Len(t, secondaryRelabels, 2)
+	assertPrometheusShardRelabels(t, secondaryRelabels, 3, "1")
+}
+
+func TestApplyPrometheusShardingLeavesUnrelatedConfigUnchanged(t *testing.T) {
+	const config = `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+`
+
+	got, changed := applyPrometheusSharding(config, &prometheusShardAssignment{
+		ClusterName: "prod",
+		ShardIndex:  0,
+		ShardCount:  2,
+	})
+
+	assert.False(t, changed)
+	assert.Equal(t, config, got)
+}
+
+func TestPrometheusShardingCalculatorUpdatesPeersOnAgentChanges(t *testing.T) {
+	const config = `
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: my-job
+`
+
+	agents := NewAgents(NewPrometheusShardingCalculator())
+
+	firstID := InstanceId{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	secondID := InstanceId{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+	firstConn := &recordingConnection{}
+	secondConn := &recordingConnection{}
+
+	first := agents.FindOrCreateAgent(firstID, firstConn)
+	first.CustomInstanceConfig = config
+	firstResponse := &protobufs.ServerToAgent{}
+	first.UpdateStatus(prometheusClusterStatus("prod"), firstResponse)
+	agents.AgentsChanged(first, firstResponse)
+
+	second := agents.FindOrCreateAgent(secondID, secondConn)
+	second.CustomInstanceConfig = config
+	secondResponse := &protobufs.ServerToAgent{}
+	second.UpdateStatus(prometheusClusterStatus("prod"), secondResponse)
+	agents.AgentsChanged(second, secondResponse)
+
+	require.Len(t, firstConn.messages, 1)
+	firstRelabels := scrapeRelabelConfigs(t, remoteConfigBody(firstConn.messages[0].RemoteConfig), "prometheus", 0)
+	assertPrometheusShardRelabels(t, firstRelabels, 2, "0")
+
+	require.NotNil(t, secondResponse.RemoteConfig)
+	secondRelabels := scrapeRelabelConfigs(t, remoteConfigBody(secondResponse.RemoteConfig), "prometheus", 0)
+	assertPrometheusShardRelabels(t, secondRelabels, 2, "1")
+
+	firstResponse = &protobufs.ServerToAgent{}
+	first.UpdateStatus(statusWithoutPrometheusCluster(), firstResponse)
+	agents.AgentsChanged(first, firstResponse)
+
+	require.NotNil(t, firstResponse.RemoteConfig)
+	assert.NotContains(t, remoteConfigBody(firstResponse.RemoteConfig), "__tmp_opamp_shard")
+
+	require.Len(t, secondConn.messages, 1)
+	secondRelabels = scrapeRelabelConfigs(t, remoteConfigBody(secondConn.messages[0].RemoteConfig), "prometheus", 0)
+	assertPrometheusShardRelabels(t, secondRelabels, 1, "0")
+}
+
+func stringAttribute(key, value string) *protobufs.KeyValue {
+	return &protobufs.KeyValue{
+		Key: key,
+		Value: &protobufs.AnyValue{
+			Value: &protobufs.AnyValue_StringValue{StringValue: value},
+		},
+	}
+}
+
+func prometheusClusterStatus(clusterName string) *protobufs.AgentToServer {
+	return &protobufs.AgentToServer{
+		Capabilities: uint64(protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig),
+		AgentDescription: &protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{
+				stringAttribute("prometheus.cluster", clusterName),
+			},
+		},
+	}
+}
+
+func statusWithoutPrometheusCluster() *protobufs.AgentToServer {
+	return &protobufs.AgentToServer{
+		SequenceNum: 1,
+		AgentDescription: &protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{
+				stringAttribute("service.name", "otelcol"),
+			},
+		},
+	}
+}
+
+func remoteConfigBody(remoteConfig *protobufs.AgentRemoteConfig) string {
+	return string(remoteConfig.Config.ConfigMap[""].Body)
+}
+
+type recordingConnection struct {
+	mux      sync.Mutex
+	messages []*protobufs.ServerToAgent
+}
+
+func (conn *recordingConnection) Connection() net.Conn {
+	return nil
+}
+
+func (conn *recordingConnection) Send(_ context.Context, message *protobufs.ServerToAgent) error {
+	conn.mux.Lock()
+	defer conn.mux.Unlock()
+
+	conn.messages = append(conn.messages, message)
+	return nil
+}
+
+func (conn *recordingConnection) Disconnect() error {
+	return nil
+}
+
+func scrapeRelabelConfigs(t *testing.T, config string, receiverName string, scrapeIndex int) []map[string]any {
+	t.Helper()
+
+	var decoded map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(config), &decoded))
+
+	receivers, ok := decoded["receivers"].(map[string]any)
+	require.True(t, ok)
+	receiver, ok := receivers[receiverName].(map[string]any)
+	require.True(t, ok)
+	receiverConfig, ok := receiver["config"].(map[string]any)
+	require.True(t, ok)
+	scrapeConfigs, ok := receiverConfig["scrape_configs"].([]any)
+	require.True(t, ok)
+	require.Greater(t, len(scrapeConfigs), scrapeIndex)
+	scrapeConfig, ok := scrapeConfigs[scrapeIndex].(map[string]any)
+	require.True(t, ok)
+	relabelConfigs, ok := scrapeConfig["relabel_configs"].([]any)
+	require.True(t, ok)
+
+	result := make([]map[string]any, 0, len(relabelConfigs))
+	for _, relabelConfig := range relabelConfigs {
+		relabelConfigMap, ok := relabelConfig.(map[string]any)
+		require.True(t, ok)
+		result = append(result, relabelConfigMap)
+	}
+	return result
+}
+
+func assertPrometheusShardRelabels(t *testing.T, relabels []map[string]any, shardCount int, shardIndexRegex string) {
+	t.Helper()
+
+	require.Len(t, relabels, 2)
+	assert.Equal(t, []any{"__address__"}, relabels[0]["source_labels"])
+	assert.Equal(t, shardCount, relabels[0]["modulus"])
+	assert.Equal(t, "__tmp_opamp_shard", relabels[0]["target_label"])
+	assert.Equal(t, "hashmod", relabels[0]["action"])
+
+	assert.Equal(t, []any{"__tmp_opamp_shard"}, relabels[1]["source_labels"])
+	assert.Equal(t, shardIndexRegex, relabels[1]["regex"])
+	assert.Equal(t, "keep", relabels[1]["action"])
+}

--- a/internal/examples/server/main.go
+++ b/internal/examples/server/main.go
@@ -26,8 +26,9 @@ func main() {
 
 	logger.Println("OpAMP Server starting...")
 
+	data.AllAgents = data.NewAgents(data.NewPrometheusShardingCalculator())
 	uisrv.Start(curDir)
-	opampSrv := opampsrv.NewServer(&data.AllAgents, emitMetrics)
+	opampSrv := opampsrv.NewServer(data.AllAgents, emitMetrics)
 	opampSrv.Start()
 
 	logger.Println("OpAMP Server running...")

--- a/internal/examples/server/opampsrv/opampsrv.go
+++ b/internal/examples/server/opampsrv/opampsrv.go
@@ -127,6 +127,7 @@ func (srv *Server) onMessage(ctx context.Context, conn types.Connection, msg *pr
 
 	// Process the status report and continue building the response.
 	agent.UpdateStatus(msg, response)
+	srv.agents.AgentsChanged(agent, response)
 
 	// Send the response back to the Agent.
 	srv.logger.Debugf(ctx, "ServerToAgent: InstanceUid=%x, %s", instanceId, formatServerToAgent(response))

--- a/internal/examples/supervisor/supervisor/supervisor_test.go
+++ b/internal/examples/supervisor/supervisor/supervisor_test.go
@@ -37,7 +37,7 @@ func changeCurrentDir(t *testing.T) string {
 func startOpampServer(t *testing.T) {
 	t.Helper()
 
-	opampSrv := opampsrv.NewServer(&data.AllAgents, false)
+	opampSrv := opampsrv.NewServer(data.AllAgents, false)
 	opampSrv.Start()
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

This adds a configurable remote config calculation layer to the example OpAMP server and uses it to support Prometheus receiver sharding across connected example agents.

Agents can now report additional non-identifying attributes via the example agent CLI/env config, and implementors of `ConfigCalculator` can use them to apply any custom logic they need. The example also adds an implementation of `ConfigCalculator` that groups Collectors by the `prometheus-cluster` attribute and manages the sharding configuration for the whole fleet when an agent connects or disconnects.