### PR TITLE
Flaky Test: Add guards to mock server's callbacks

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -303,7 +303,7 @@ func TestClientWithLastConnectionStatus(t *testing.T) {
 		gotSettings := new(atomic.Bool)
 		srv := internal.StartMockServer(t)
 		defer srv.Close()
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			t.Log("Got message")
 			if msg.ConnectionSettingsStatus != nil {
 				gotSettings.Store(true)
@@ -311,7 +311,7 @@ func TestClientWithLastConnectionStatus(t *testing.T) {
 			return &protobufs.ServerToAgent{
 				InstanceUid: msg.InstanceUid,
 			}
-		}
+		})
 
 		capabilities := coreCapabilities | protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus
 		settings := types.StartSettings{
@@ -377,13 +377,13 @@ func TestConnectWithServer503(t *testing.T) {
 		// Start a server.
 		var connectionAttempts int64
 		srv := internal.StartMockServer(t)
-		srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
+		srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
 			atomic.StoreInt64(&connectionAttempts, 1)
 
 			// Always respond with an error to the client.
 			w.Header().Set(retryAfterHTTPHeader, "30")
 			w.WriteHeader(http.StatusServiceUnavailable)
-		}
+		})
 
 		// Start a client.
 		var clientConnected int64
@@ -419,13 +419,13 @@ func TestConnectWithHeader(t *testing.T) {
 		// Start a server.
 		srv := internal.StartMockServer(t)
 		var conn atomic.Value
-		srv.OnConnect = func(r *http.Request) {
+		srv.SetOnConnect(func(r *http.Request) {
 			authHdr := r.Header.Get("Authorization")
 			assert.EqualValues(t, "Bearer 12345678", authHdr)
 			userAgentHdr := r.Header.Get("User-Agent")
 			assert.EqualValues(t, "custom-agent/1.0", userAgentHdr)
 			conn.Store(true)
-		}
+		})
 
 		header := http.Header{}
 		header.Set("Authorization", "Bearer 12345678")
@@ -452,13 +452,13 @@ func TestConnectWithHeaderFunc(t *testing.T) {
 		// Start a server.
 		srv := internal.StartMockServer(t)
 		var conn atomic.Value
-		srv.OnConnect = func(r *http.Request) {
+		srv.SetOnConnect(func(r *http.Request) {
 			authHdr := r.Header.Get("Authorization")
 			assert.EqualValues(t, "Bearer 12345678", authHdr)
 			userAgentHdr := r.Header.Get("User-Agent")
 			assert.EqualValues(t, "custom-agent/1.0", userAgentHdr)
 			conn.Store(true)
-		}
+		})
 
 		hf := func(header http.Header) http.Header {
 			header.Set("Authorization", "Bearer 12345678")
@@ -487,13 +487,13 @@ func TestConnectWithHeaderAndHeaderFunc(t *testing.T) {
 		// Start a server.
 		srv := internal.StartMockServer(t)
 		var conn atomic.Value
-		srv.OnConnect = func(r *http.Request) {
+		srv.SetOnConnect(func(r *http.Request) {
 			authHdr := r.Header.Get("Authorization")
 			assert.EqualValues(t, "Bearer 12345678", authHdr)
 			userAgentHdr := r.Header.Get("User-Agent")
 			assert.EqualValues(t, "custom-agent/1.0", userAgentHdr)
 			conn.Store(true)
-		}
+		})
 
 		baseHeader := http.Header{}
 		baseHeader.Set("User-Agent", "custom-agent/1.0")
@@ -525,9 +525,9 @@ func TestConnectWithTLS(t *testing.T) {
 		// Start a server.
 		srv := internal.StartTLSMockServer(t)
 		var conn atomic.Value
-		srv.OnConnect = func(r *http.Request) {
+		srv.SetOnConnect(func(r *http.Request) {
 			conn.Store(true)
-		}
+		})
 
 		certs := rootCAs(t, srv.GetHTTPTestServer())
 
@@ -581,7 +581,7 @@ func TestFirstStatusReport(t *testing.T) {
 		srv := internal.StartMockServer(t)
 		var isFirstSrvMessage atomic.Bool
 		isFirstSrvMessage.Store(true)
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if isFirstSrvMessage.Load() {
 				isFirstSrvMessage.Store(false)
 				assert.EqualValues(t, 0, msg.SequenceNum)
@@ -591,7 +591,7 @@ func TestFirstStatusReport(t *testing.T) {
 				}
 			}
 			return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
-		}
+		})
 
 		// Start a client.
 		var isFirstClientMessage atomic.Bool
@@ -636,7 +636,7 @@ func TestExcludesDetailsOnReconnect(t *testing.T) {
 	srv := internal.StartMockServer(t)
 
 	var receivedDetails int64
-	srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 		// Track when we receive AgentDescription
 		if msg.AgentDescription != nil {
 			atomic.AddInt64(&receivedDetails, 1)
@@ -645,7 +645,7 @@ func TestExcludesDetailsOnReconnect(t *testing.T) {
 		return &protobufs.ServerToAgent{
 			InstanceUid: msg.InstanceUid,
 		}
-	}
+	})
 
 	var connected int64
 	settings := types.StartSettings{
@@ -692,12 +692,12 @@ func TestSetEffectiveConfig(t *testing.T) {
 		// Start a server.
 		srv := internal.StartMockServer(t)
 		var rcvConfig atomic.Value
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg.EffectiveConfig != nil {
 				rcvConfig.Store(msg.EffectiveConfig)
 			}
 			return nil
-		}
+		})
 
 		// Start a client.
 		sendConfig := createEffectiveConfig()
@@ -751,12 +751,12 @@ func TestSetAgentDescription(t *testing.T) {
 		// Start a Server.
 		srv := internal.StartMockServer(t)
 		var rcvAgentDescr atomic.Value
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg.AgentDescription != nil {
 				rcvAgentDescr.Store(msg.AgentDescription)
 			}
 			return nil
-		}
+		})
 
 		// Start a client.
 		settings := types.StartSettings{
@@ -818,7 +818,7 @@ func TestAgentIdentification(t *testing.T) {
 		var newInstanceUid atomic.Value
 		newInstanceUid.Store(genNewInstanceUid(t))
 		var rcvAgentInstanceUid atomic.Value
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg.Flags&uint64(protobufs.AgentToServerFlags_AgentToServerFlags_RequestInstanceUid) == 1 {
 				uid := genNewInstanceUid(t)
 				newInstanceUid.Store(uid)
@@ -836,7 +836,7 @@ func TestAgentIdentification(t *testing.T) {
 			return &protobufs.ServerToAgent{
 				InstanceUid: msg.InstanceUid,
 			}
-		}
+		})
 
 		// Start a client.
 		settings := types.StartSettings{}
@@ -910,7 +910,7 @@ func TestServerOfferConnectionSettings(t *testing.T) {
 		var rcvStatus int64
 		// Start a Server.
 		srv := internal.StartMockServer(t)
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg != nil {
 				atomic.AddInt64(&rcvStatus, 1)
 
@@ -928,7 +928,7 @@ func TestServerOfferConnectionSettings(t *testing.T) {
 				}
 			}
 			return nil
-		}
+		})
 
 		var gotOpampSettings int64
 		var gotOwnSettings int64
@@ -990,7 +990,7 @@ func TestClientRequestConnectionSettings(t *testing.T) {
 			var srvReceivedRequest int64
 			// Start a Server.
 			srv := internal.StartMockServer(t)
-			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				if msg != nil && msg.ConnectionSettingsRequest != nil {
 					atomic.AddInt64(&srvReceivedRequest, 1)
 					return &protobufs.ServerToAgent{
@@ -1000,7 +1000,7 @@ func TestClientRequestConnectionSettings(t *testing.T) {
 					}
 				}
 				return nil
-			}
+			})
 
 			var clientGotOpampSettings int64
 
@@ -2142,12 +2142,12 @@ func TestCustomMessages(t *testing.T) {
 		// Start a Server.
 		srv := internal.StartMockServer(t)
 		var rcvCustomMessage atomic.Value
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg.CustomMessage != nil {
 				rcvCustomMessage.Store(msg.CustomMessage)
 			}
 			return nil
-		}
+		})
 
 		// Start a client.
 		settings := types.StartSettings{
@@ -2217,12 +2217,12 @@ func TestSendCustomMessagePendingError(t *testing.T) {
 		// Start a Server.
 		srv := internal.StartMockServer(t)
 		var rcvCustomMessage atomic.Value
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg.CustomMessage != nil {
 				rcvCustomMessage.Store(msg.CustomMessage)
 			}
 			return nil
-		}
+		})
 
 		// Start a client.
 		settings := types.StartSettings{
@@ -2310,7 +2310,7 @@ func TestCustomMessagesSendAndWait(t *testing.T) {
 
 		// The OnMessage callback puts CustomMessages on a channel to be verified
 		rcvCustomMessages := make(chan *protobufs.CustomMessage)
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg.CustomMessage != nil {
 				select {
 				case rcvCustomMessages <- msg.CustomMessage:
@@ -2319,7 +2319,7 @@ func TestCustomMessagesSendAndWait(t *testing.T) {
 				}
 			}
 			return nil
-		}
+		})
 
 		// Start a client.
 		settings := types.StartSettings{
@@ -2375,7 +2375,7 @@ func TestSetCustomCapabilities(t *testing.T) {
 		srv := internal.StartMockServer(t)
 		var rcvCustomCapabilities atomic.Value
 		var rcvCustomMessage atomic.Value
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg.CustomMessage != nil {
 				rcvCustomMessage.Store(msg.CustomMessage)
 			}
@@ -2383,7 +2383,7 @@ func TestSetCustomCapabilities(t *testing.T) {
 				rcvCustomCapabilities.Store(msg.CustomCapabilities)
 			}
 			return nil
-		}
+		})
 
 		// Start a client with no support for CustomCapabilities
 		settings := types.StartSettings{
@@ -2458,12 +2458,12 @@ func TestSetFlags(t *testing.T) {
 		var rcvCustomFlags atomic.Value
 		var flags protobufs.AgentToServerFlags
 
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg.Flags != 0 {
 				rcvCustomFlags.Store(msg.Flags)
 			}
 			return nil
-		}
+		})
 
 		settings := types.StartSettings{}
 		settings.OpAMPServerURL = "ws://" + srv.Endpoint
@@ -2510,13 +2510,13 @@ func TestSetFlagsBeforeStart(t *testing.T) {
 		isFirstMessage.Store(true)
 
 		// Make sure we only record flags from the very first message.
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if isFirstMessage.Load() {
 				rcvCustomFlags.Store(msg.Flags)
 			}
 			isFirstMessage.Store(false)
 			return nil
-		}
+		})
 
 		settings := types.StartSettings{}
 		settings.OpAMPServerURL = "ws://" + srv.Endpoint
@@ -2769,7 +2769,7 @@ func TestConnectionSettingsFilteredByCapability(t *testing.T) {
 
 		srv := internal.StartMockServer(t)
 		firstMessage := true
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if firstMessage {
 				firstMessage = false
 				return &protobufs.ServerToAgent{
@@ -2786,7 +2786,7 @@ func TestConnectionSettingsFilteredByCapability(t *testing.T) {
 				}
 			}
 			return &protobufs.ServerToAgent{InstanceUid: msg.InstanceUid}
-		}
+		})
 
 		var gotCallback atomic.Bool
 		// Only enable ReportsOwnMetrics — traces, logs, other should be filtered out.
@@ -3125,7 +3125,7 @@ func TestSetConnectionSettingsStatus(t *testing.T) {
 					srv = internal.StartMockServer(t)
 					defer srv.Close()
 					messageDispatcher := newMockServerMessageDispatcher()
-					srv.OnMessage = messageDispatcher.Handle
+					srv.SetOnMessage(messageDispatcher.Handle)
 					setOnMessage = messageDispatcher.Set
 					settings.OpAMPServerURL = "ws://" + srv.Endpoint
 				} else {
@@ -3157,7 +3157,7 @@ func TestSetConnectionSettingsStatusAsync(t *testing.T) {
 		defer srv.Close()
 
 		firstMessage := true
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if msg.ConnectionSettingsStatus != nil {
 				switch msg.ConnectionSettingsStatus.Status {
 				case protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_APPLYING:
@@ -3175,7 +3175,7 @@ func TestSetConnectionSettingsStatusAsync(t *testing.T) {
 				}
 			}
 			return resp
-		}
+		})
 
 		capabilities := coreCapabilities |
 			protobufs.AgentCapabilities_AgentCapabilities_AcceptsOpAMPConnectionSettings |

--- a/client/httpclient_test.go
+++ b/client/httpclient_test.go
@@ -42,11 +42,11 @@ func TestHTTPClientUsesStartSettingsClient(t *testing.T) {
 	defer srv.Close()
 
 	var rcvCounter int64
-	srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 		require.NotNil(t, msg)
 		atomic.AddInt64(&rcvCounter, 1)
 		return nil
-	}
+	})
 
 	transport := &recordingRoundTripper{base: http.DefaultTransport}
 	settings := types.StartSettings{
@@ -72,7 +72,7 @@ func TestHTTPPolling(t *testing.T) {
 	// Start a Server.
 	srv := internal.StartMockServer(t)
 	var rcvCounter int64
-	srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 		if msg == nil {
 			t.Error("unexpected nil msg")
 			return nil
@@ -80,7 +80,7 @@ func TestHTTPPolling(t *testing.T) {
 		assert.EqualValues(t, rcvCounter, msg.SequenceNum)
 		atomic.AddInt64(&rcvCounter, 1)
 		return nil
-	}
+	})
 
 	// Start a client.
 	settings := types.StartSettings{}
@@ -111,7 +111,7 @@ func TestHTTPClientCompression(t *testing.T) {
 	srv := internal.StartMockServer(t)
 	var reqCounter int64
 
-	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
+	srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&reqCounter, 1)
 		assert.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
 		reader, err := gzip.NewReader(r.Body)
@@ -141,7 +141,7 @@ func TestHTTPClientCompression(t *testing.T) {
 			},
 		})
 		w.WriteHeader(http.StatusOK)
-	}
+	})
 
 	settings := types.StartSettings{EnableCompression: true}
 	settings.OpAMPServerURL = "http://" + srv.Endpoint
@@ -164,7 +164,7 @@ func TestHTTPClientSetPollingInterval(t *testing.T) {
 	// Start a Server.
 	srv := internal.StartMockServer(t)
 	var rcvCounter int64
-	srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 		if msg == nil {
 			t.Error("unexpected nil msg")
 			return nil
@@ -172,7 +172,7 @@ func TestHTTPClientSetPollingInterval(t *testing.T) {
 		assert.EqualValues(t, rcvCounter, msg.SequenceNum)
 		atomic.AddInt64(&rcvCounter, 1)
 		return nil
-	}
+	})
 
 	// Start a client.
 	settings := types.StartSettings{}
@@ -212,7 +212,7 @@ func TestHTTPClientStartWithHeartbeatInterval(t *testing.T) {
 			// Start a Server.
 			srv := internal.StartMockServer(t)
 			var rcvCounter int64
-			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				if msg == nil {
 					t.Error("unexpected nil msg")
 					return nil
@@ -220,7 +220,7 @@ func TestHTTPClientStartWithHeartbeatInterval(t *testing.T) {
 				assert.EqualValues(t, rcvCounter, msg.SequenceNum)
 				atomic.AddInt64(&rcvCounter, 1)
 				return nil
-			}
+			})
 
 			// Start a client.
 			heartbeat := 10 * time.Millisecond
@@ -387,7 +387,7 @@ func TestHTTPReportsAvailableComponents(t *testing.T) {
 			// Start a Server.
 			srv := internal.StartMockServer(t)
 			var rcvCounter atomic.Uint64
-			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				assert.EqualValues(t, rcvCounter.Load(), msg.SequenceNum)
 				rcvCounter.Add(1)
 				time.Sleep(50 * time.Millisecond)
@@ -429,7 +429,7 @@ func TestHTTPReportsAvailableComponents(t *testing.T) {
 				// all subsequent messages should not have any available components
 				require.Nil(t, msg.GetAvailableComponents())
 				return nil
-			}
+			})
 
 			// Start a client.
 			settings := types.StartSettings{}
@@ -494,7 +494,7 @@ func TestHTTPSenderOpAMPInstanceUIDHeader(t *testing.T) {
 	// Start a server.
 	srv := internal.StartMockServer(t)
 	var connCnt atomic.Int32
-	srv.OnConnect = func(r *http.Request) {
+	srv.SetOnConnect(func(r *http.Request) {
 		// Get request header
 		hdrUid := r.Header.Get("OpAMP-Instance-UID")
 
@@ -510,8 +510,8 @@ func TestHTTPSenderOpAMPInstanceUIDHeader(t *testing.T) {
 		assert.EqualValues(t, uid.String(), hdrUid)
 
 		connCnt.Add(1)
-	}
-	srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	})
+	srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 		return &protobufs.ServerToAgent{
 			InstanceUid: msg.InstanceUid,
 			AgentIdentification: &protobufs.AgentIdentification{
@@ -519,7 +519,7 @@ func TestHTTPSenderOpAMPInstanceUIDHeader(t *testing.T) {
 			},
 			Flags: uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState),
 		}
-	}
+	})
 
 	header := http.Header{}
 

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -33,7 +33,7 @@ func newTestHTTPSender() *HTTPSender {
 func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
 	var connectionAttempts int64
 	srv := StartMockServer(t)
-	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
+	srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
 		attempt := atomic.AddInt64(&connectionAttempts, 1)
 		// Return a Retry-After header with a value of 1 second for first attempt.
 		if attempt == 1 {
@@ -42,7 +42,7 @@ func TestHTTPSenderRetryForStatusTooManyRequests(t *testing.T) {
 		} else {
 			w.WriteHeader(http.StatusOK)
 		}
-	}
+	})
 	ctx, cancel := context.WithCancel(context.Background())
 	url := "http://" + srv.Endpoint
 	sender := newTestHTTPSender()
@@ -219,7 +219,7 @@ func TestHTTPSenderRetryForFailedRequests(t *testing.T) {
 	var connectionAttempts int64
 
 	var buf []byte
-	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
+	srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
 		attempt := atomic.AddInt64(&connectionAttempts, 1)
 		if attempt == 1 {
 			hj, ok := w.(http.Hijacker)
@@ -237,7 +237,7 @@ func TestHTTPSenderRetryForFailedRequests(t *testing.T) {
 			buf, _ = io.ReadAll(r.Body)
 			w.WriteHeader(http.StatusOK)
 		}
-	}
+	})
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	url := "http://" + address
 	sender := newTestHTTPSender()
@@ -555,9 +555,9 @@ func TestHTTPSenderSetProxy(t *testing.T) {
 
 		srv := StartTLSMockServer(t)
 		t.Cleanup(srv.Close)
-		srv.OnRequest = func(w http.ResponseWriter, _ *http.Request) {
+		srv.SetOnRequest(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		}
+		})
 
 		sender := newTestHTTPSender()
 		sender.client = proxyServer.Client()
@@ -627,7 +627,7 @@ func TestHTTPSenderClosesBody(t *testing.T) {
 			srv := StartMockServer(t)
 			t.Cleanup(srv.Close)
 
-			srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
+			srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
 				attempt := atomic.AddInt64(&connectionAttempts, 1)
 				if tt.shouldRetry && attempt == 1 {
 					w.Header().Set("Retry-After", "0")
@@ -637,7 +637,7 @@ func TestHTTPSenderClosesBody(t *testing.T) {
 					w.WriteHeader(tt.eventualStatus)
 					w.Write([]byte("test"))
 				}
-			}
+			})
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
@@ -725,11 +725,11 @@ func TestHTTPSenderOpAMPInstanceUIDHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	srv := StartMockServer(t)
-	srv.OnRequest = func(w http.ResponseWriter, r *http.Request) {
+	srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
 		// Verify that request header contains the correct OpAMP Instance UID
 		assert.EqualValues(t, r.Header.Get(headerOpAMPInstanceUID), uid.String())
 		w.WriteHeader(http.StatusOK)
-	}
+	})
 	url := "http://" + srv.Endpoint
 	sender := newTestHTTPSender()
 

--- a/client/internal/mockserver.go
+++ b/client/internal/mockserver.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,18 +21,44 @@ import (
 type receivedMessageHandler func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent
 
 type MockServer struct {
-	t           *testing.T
-	Endpoint    string
-	OnRequest   func(w http.ResponseWriter, r *http.Request)
-	OnConnect   func(r *http.Request)
-	OnWSConnect func(conn *websocket.Conn)
-	OnMessage   func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent
-	srv         *httptest.Server
+	t        *testing.T
+	Endpoint string
+	srv      *httptest.Server
+
+	mu          sync.RWMutex
+	onRequest   func(w http.ResponseWriter, r *http.Request)
+	onConnect   func(r *http.Request)
+	onWSConnect func(conn *websocket.Conn)
+	onMessage   func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent
 
 	expectedHandlers  chan receivedMessageHandler
 	expectedComplete  chan struct{}
 	isExpectMode      bool
 	enableCompression bool
+}
+
+func (m *MockServer) SetOnRequest(f func(w http.ResponseWriter, r *http.Request)) {
+	m.mu.Lock()
+	m.onRequest = f
+	m.mu.Unlock()
+}
+
+func (m *MockServer) SetOnConnect(f func(r *http.Request)) {
+	m.mu.Lock()
+	m.onConnect = f
+	m.mu.Unlock()
+}
+
+func (m *MockServer) SetOnWSConnect(f func(conn *websocket.Conn)) {
+	m.mu.Lock()
+	m.onWSConnect = f
+	m.mu.Unlock()
+}
+
+func (m *MockServer) SetOnMessage(f func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent) {
+	m.mu.Lock()
+	m.onMessage = f
+	m.mu.Unlock()
 }
 
 func newMockServer(t *testing.T) (*MockServer, *http.ServeMux) {
@@ -44,13 +71,18 @@ func newMockServer(t *testing.T) (*MockServer, *http.ServeMux) {
 	m := http.NewServeMux()
 	m.HandleFunc(
 		"/", func(w http.ResponseWriter, r *http.Request) {
-			if srv.OnRequest != nil {
-				srv.OnRequest(w, r)
+			srv.mu.RLock()
+			onRequest := srv.onRequest
+			onConnect := srv.onConnect
+			srv.mu.RUnlock()
+
+			if onRequest != nil {
+				onRequest(w, r)
 				return
 			}
 
-			if srv.OnConnect != nil {
-				srv.OnConnect(r)
+			if onConnect != nil {
+				onConnect(r)
 			}
 
 			if r.Header.Get(headerContentType) == contentTypeProtobuf {
@@ -141,8 +173,11 @@ func (m *MockServer) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	if m.OnWSConnect != nil {
-		m.OnWSConnect(conn)
+	m.mu.RLock()
+	onWSConnect := m.onWSConnect
+	m.mu.RUnlock()
+	if onWSConnect != nil {
+		onWSConnect(conn)
 	}
 	for {
 		var messageType int
@@ -195,9 +230,13 @@ func (m *MockServer) handleReceivedBytes(msgBytes []byte, alwaysRespond bool) []
 		case <-t.C:
 			m.t.Error("Time out waiting for Expect() to handle the received message")
 		}
-	} else if m.OnMessage != nil {
-		// Not in expect mode, instead using OnMessage callback.
-		response = m.OnMessage(&request)
+	} else {
+		m.mu.RLock()
+		onMessage := m.onMessage
+		m.mu.RUnlock()
+		if onMessage != nil {
+			response = onMessage(&request)
+		}
 	}
 
 	if alwaysRespond && response == nil {

--- a/client/internal/wssender_test.go
+++ b/client/internal/wssender_test.go
@@ -26,7 +26,7 @@ func TestWSSenderWriteWSMessageFailure_BrokenPipe(t *testing.T) {
 	// after a short delay so the client's send will hit the closed connection
 	// and fail with connection reset.
 	connCloseCh := make(chan error)
-	srv.OnWSConnect = func(conn *websocket.Conn) {
+	srv.SetOnWSConnect(func(conn *websocket.Conn) {
 		go func() {
 			if tcpConn, ok := conn.NetConn().(*net.TCPConn); ok {
 				// setting linger to 0 to prevent os from doing graceful close
@@ -37,7 +37,7 @@ func TestWSSenderWriteWSMessageFailure_BrokenPipe(t *testing.T) {
 			// we can be sure that connection is killed
 			connCloseCh <- conn.NetConn().Close()
 		}()
-	}
+	})
 
 	conn, _, err := websocket.DefaultDialer.DialContext(
 		context.Background(),

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -44,12 +44,12 @@ func TestWSSenderReportsHeartbeat(t *testing.T) {
 
 		var firstMsg atomic.Bool
 		var conn atomic.Value
-		srv.OnWSConnect = func(c *websocket.Conn) {
+		srv.SetOnWSConnect(func(c *websocket.Conn) {
 			conn.Store(c)
 			firstMsg.Store(true)
-		}
+		})
 		var msgCount atomic.Int64
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if firstMsg.Load() {
 				firstMsg.Store(false)
 				resp := &protobufs.ServerToAgent{
@@ -67,7 +67,7 @@ func TestWSSenderReportsHeartbeat(t *testing.T) {
 			}
 			msgCount.Add(1)
 			return nil
-		}
+		})
 
 		// Start an OpAMP/WebSocket client.
 		settings := types.StartSettings{
@@ -113,14 +113,14 @@ func TestWSClientStartWithHeartbeatInterval(t *testing.T) {
 			srv := internal.StartMockServer(t)
 
 			var conn atomic.Value
-			srv.OnWSConnect = func(c *websocket.Conn) {
+			srv.SetOnWSConnect(func(c *websocket.Conn) {
 				conn.Store(c)
-			}
+			})
 			var msgCount atomic.Int64
-			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				msgCount.Add(1)
 				return nil
-			}
+			})
 
 			// Start an OpAMP/WebSocket client.
 			heartbeat := 10 * time.Millisecond
@@ -159,9 +159,9 @@ func TestDisconnectWSByServer(t *testing.T) {
 	srv := internal.StartMockServer(t)
 
 	var conn atomic.Value
-	srv.OnWSConnect = func(c *websocket.Conn) {
+	srv.SetOnWSConnect(func(c *websocket.Conn) {
 		conn.Store(c)
-	}
+	})
 
 	// Start an OpAMP/WebSocket client.
 	var connected int64
@@ -416,9 +416,9 @@ func TestRedirectWS(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			var conn atomic.Value
-			redirectee.OnWSConnect = func(c *websocket.Conn) {
+			redirectee.SetOnWSConnect(func(c *websocket.Conn) {
 				conn.Store(c)
-			}
+			})
 
 			// Start an OpAMP/WebSocket client.
 			var connected int64
@@ -480,9 +480,9 @@ func TestRedirectWSFollowChain(t *testing.T) {
 	redirector := redirectServer("http://"+middleURL.Host, 302)
 
 	var conn atomic.Value
-	redirectee.OnWSConnect = func(c *websocket.Conn) {
+	redirectee.SetOnWSConnect(func(c *websocket.Conn) {
 		conn.Store(c)
-	}
+	})
 
 	// Start an OpAMP/WebSocket client.
 	var connected int64
@@ -535,10 +535,10 @@ func TestPerformsClosingHandshake(t *testing.T) {
 	closed := make(chan struct{})
 	acked := make(chan struct{})
 
-	srv.OnWSConnect = func(conn *websocket.Conn) {
+	srv.SetOnWSConnect(func(conn *websocket.Conn) {
 		wsConn = conn
 		connected <- struct{}{}
-	}
+	})
 
 	client := NewWebSocket(nil)
 	startClient(t, types.StartSettings{
@@ -596,10 +596,10 @@ func TestHandlesSlowCloseMessageFromServer(t *testing.T) {
 	connected := make(chan struct{})
 	closed := make(chan struct{})
 
-	srv.OnWSConnect = func(conn *websocket.Conn) {
+	srv.SetOnWSConnect(func(conn *websocket.Conn) {
 		wsConn = conn
 		connected <- struct{}{}
-	}
+	})
 
 	client := NewWebSocket(nil)
 	client.connShutdownTimeout = 100 * time.Millisecond
@@ -676,10 +676,10 @@ func TestHandlesNoCloseMessageFromServer(t *testing.T) {
 	connected := make(chan struct{})
 	closed := make(chan struct{})
 
-	srv.OnWSConnect = func(conn *websocket.Conn) {
+	srv.SetOnWSConnect(func(conn *websocket.Conn) {
 		wsConn = conn
 		connected <- struct{}{}
-	}
+	})
 
 	client := NewWebSocket(nil)
 	client.connShutdownTimeout = 100 * time.Millisecond
@@ -722,10 +722,10 @@ func TestHandlesConnectionError(t *testing.T) {
 	var wsConn *websocket.Conn
 	connected := make(chan struct{})
 
-	srv.OnWSConnect = func(conn *websocket.Conn) {
+	srv.SetOnWSConnect(func(conn *websocket.Conn) {
 		wsConn = conn
 		connected <- struct{}{}
-	}
+	})
 
 	client := NewWebSocket(nil)
 	startClient(t, types.StartSettings{
@@ -794,12 +794,12 @@ func TestWSSenderReportsAvailableComponents(t *testing.T) {
 			var firstMsg atomic.Bool
 			var conn atomic.Value
 			var availableComponentsMsgReceived atomic.Bool
-			srv.OnWSConnect = func(c *websocket.Conn) {
+			srv.SetOnWSConnect(func(c *websocket.Conn) {
 				conn.Store(c)
 				firstMsg.Store(true)
-			}
+			})
 			var msgCount atomic.Int64
-			srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				if firstMsg.Load() {
 					msgCount.Add(1)
 					firstMsg.Store(false)
@@ -834,7 +834,7 @@ func TestWSSenderReportsAvailableComponents(t *testing.T) {
 				}
 
 				return nil
-			}
+			})
 
 			// Start an OpAMP/WebSocket client.
 			settings := types.StartSettings{
@@ -874,15 +874,15 @@ func TestReconnectDoesNotSendFirstMessage(t *testing.T) {
 		srv := internal.StartMockServer(t)
 
 		var serverConn atomic.Pointer[websocket.Conn]
-		srv.OnWSConnect = func(conn *websocket.Conn) {
+		srv.SetOnWSConnect(func(conn *websocket.Conn) {
 			serverConn.Store(conn)
-		}
+		})
 
 		firstMsgCh := make(chan *protobufs.AgentToServer, 1)
 		reconnectMsgCh := make(chan *protobufs.AgentToServer, 1)
 		var connectCount atomic.Int32
 
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if connectCount.Load() == 1 {
 				select {
 				case firstMsgCh <- proto.Clone(msg).(*protobufs.AgentToServer):
@@ -895,7 +895,7 @@ func TestReconnectDoesNotSendFirstMessage(t *testing.T) {
 				}
 			}
 			return nil
-		}
+		})
 
 		client := NewWebSocket(nil)
 		reconnected := make(chan struct{}, 1)
@@ -958,15 +958,15 @@ func TestReconnectDoesNotSendFirstMessage(t *testing.T) {
 		srv := internal.StartMockServer(t)
 
 		var serverConn atomic.Pointer[websocket.Conn]
-		srv.OnWSConnect = func(conn *websocket.Conn) {
+		srv.SetOnWSConnect(func(conn *websocket.Conn) {
 			serverConn.Store(conn)
-		}
+		})
 
 		firstMsgCh := make(chan *protobufs.AgentToServer, 1)
 		reconnectMsgCh := make(chan *protobufs.AgentToServer, 1)
 		var connectCount atomic.Int32
 
-		srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			if connectCount.Load() == 1 {
 				select {
 				case firstMsgCh <- proto.Clone(msg).(*protobufs.AgentToServer):
@@ -979,7 +979,7 @@ func TestReconnectDoesNotSendFirstMessage(t *testing.T) {
 				}
 			}
 			return nil
-		}
+		})
 
 		client := NewWebSocket(nil)
 		reconnected := make(chan struct{}, 1)
@@ -1150,10 +1150,10 @@ func TestWSClientUseHTTPProxy(t *testing.T) {
 	var serverConnected atomic.Bool
 	srv := internal.StartMockServer(t)
 	t.Cleanup(srv.Close)
-	srv.OnMessage = func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 		serverConnected.Store(true)
 		return nil
-	}
+	})
 	t.Logf("Server endpoint: %s", srv.Endpoint)
 
 	settings := types.StartSettings{


### PR DESCRIPTION
Add guards so that if a callback changes for a running mock server the test will not encounter a datarace and fail.

- Closes https://github.com/open-telemetry/opamp-go/issues/579