### PR TITLE
Fix build broken by #570

### DIFF
--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -288,10 +288,10 @@ func TestHTTPSenderRequestBodySizeLimit(t *testing.T) {
 	var calls atomic.Int64
 	srv := StartMockServer(t)
 	t.Cleanup(srv.Close)
-	srv.OnRequest = func(w http.ResponseWriter, _ *http.Request) {
+	srv.SetOnRequest(func(w http.ResponseWriter, _ *http.Request) {
 		calls.Add(1)
 		w.WriteHeader(http.StatusOK)
-	}
+	})
 
 	sender := setupTestSender(t, "http://"+srv.Endpoint)
 	sender.SetMaxMessageSize(1)
@@ -436,13 +436,13 @@ func TestHTTPSenderResponseBodySizeLimitFromServer(t *testing.T) {
 			var calls atomic.Int64
 			srv := StartMockServer(t)
 			t.Cleanup(srv.Close)
-			srv.OnRequest = func(w http.ResponseWriter, _ *http.Request) {
+			srv.SetOnRequest(func(w http.ResponseWriter, _ *http.Request) {
 				calls.Add(1)
 				w.WriteHeader(tc.status)
 				_, _ = w.Write([]byte("too large body"))
-			}
+			})
 
-			sender := NewHTTPSender(&sharedinternal.NopLogger{})
+			sender := newTestHTTPSender()
 			sender.SetMaxMessageSize(10)
 			sender.url = "http://" + srv.Endpoint
 			sender.callbacks.SetDefaults()


### PR DESCRIPTION
Fixed httpSender creation in the tests and OnRequest callback setting.

Github action didn't catch this because we didn't rebase from latest main.