### PR TITLE
Expose BackoffPolicy in StartSettings

### DIFF
--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,6 +94,18 @@ func TestConnectInvalidURL(t *testing.T) {
 
 func eventually(t *testing.T, f func() bool) {
 	assert.Eventually(t, f, 5*time.Second, 10*time.Millisecond)
+}
+
+// mockBackoffPolicy is a BackoffPolicy that returns a fixed interval and records
+// how many times NextBackOff has been called. Used in tests.
+type mockBackoffPolicy struct {
+	interval time.Duration
+	calls    atomic.Int64
+}
+
+func (p *mockBackoffPolicy) NextBackOff() time.Duration {
+	p.calls.Add(1)
+	return p.interval
 }
 
 type mockServerMessageHandler func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent
@@ -3205,5 +3218,69 @@ func TestSetConnectionSettingsStatusAsync(t *testing.T) {
 
 		err = client.Stop(t.Context())
 		require.NoError(t, err)
+	})
+}
+
+// TestClientCenkaltiBackoffPolicy verifies that a cenkalti/backoff
+// *ExponentialBackOff with custom values satisfies the BackoffPolicy interface
+// and works correctly with both transport implementations.
+func TestClientCenkaltiBackoffPolicy(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		b := backoff.NewExponentialBackOff(
+			backoff.WithInitialInterval(10*time.Millisecond),
+			backoff.WithMultiplier(1.5),
+			backoff.WithMaxInterval(100*time.Millisecond),
+			backoff.WithMaxElapsedTime(0), // retry indefinitely
+		)
+
+		srv := internal.StartMockServer(t)
+		t.Cleanup(srv.Close)
+
+		var gotMessage atomic.Bool
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			gotMessage.Store(true)
+			return nil
+		})
+
+		settings := types.StartSettings{
+			OpAMPServerURL: srv.GetHTTPTestServer().URL,
+			BackoffPolicy:  b,
+		}
+		startClient(t, settings, client)
+
+		eventually(t, func() bool { return gotMessage.Load() })
+
+		require.NoError(t, client.Stop(context.Background()))
+	})
+}
+
+// TestClientBackoffPolicyIsConsulted verifies that a BackoffPolicy provided in
+// StartSettings is consulted by both transport implementations.
+func TestClientBackoffPolicyIsConsulted(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		policy := &mockBackoffPolicy{interval: 1 * time.Millisecond}
+
+		srv := internal.StartMockServer(t)
+		t.Cleanup(srv.Close)
+
+		var gotMessage atomic.Bool
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			gotMessage.Store(true)
+			return nil
+		})
+
+		settings := types.StartSettings{
+			OpAMPServerURL: srv.GetHTTPTestServer().URL,
+			BackoffPolicy:  policy,
+		}
+		startClient(t, settings, client)
+
+		eventually(t, func() bool { return gotMessage.Load() })
+
+		// The policy must have been consulted at least once during the connection
+		// or request cycle.
+		assert.GreaterOrEqual(t, policy.calls.Load(), int64(1))
+
+		require.NoError(t, client.Stop(context.Background()))
 	})
 }

--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -3244,7 +3244,7 @@ func TestClientCenkaltiBackoffPolicy(t *testing.T) {
 
 		settings := types.StartSettings{
 			OpAMPServerURL: srv.GetHTTPTestServer().URL,
-			BackoffPolicy:  b,
+			BackoffPolicy:  func() types.BackoffPolicy { return b },
 		}
 		startClient(t, settings, client)
 
@@ -3271,7 +3271,7 @@ func TestClientBackoffPolicyIsConsulted(t *testing.T) {
 
 		settings := types.StartSettings{
 			OpAMPServerURL: srv.GetHTTPTestServer().URL,
-			BackoffPolicy:  policy,
+			BackoffPolicy:  func() types.BackoffPolicy { return policy },
 		}
 		startClient(t, settings, client)
 

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -69,6 +69,8 @@ func (c *httpClient) Start(ctx context.Context, settings types.StartSettings) er
 		}
 	}
 
+	c.sender.SetBackoffPolicy(settings.BackoffPolicy)
+
 	// Prepare the first message to send.
 	err := c.common.PrepareFirstMessage(ctx)
 	if err != nil {

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -252,7 +252,7 @@ func (h *HTTPSender) sendRequestWithRetries(ctx context.Context) (*http.Response
 		timer := time.NewTimer(interval)
 		next := bpolicy.NextBackOff()
 		if next < 0 {
-			next = backoff.DefaultMaxInterval
+			return nil, errors.New("invalid backoff policy time")
 		}
 		interval = next
 

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -70,6 +70,9 @@ type HTTPSender struct {
 
 	// Processor to handle received messages.
 	receiveProcessor receivedProcessor
+
+	// backoffPolicy controls the delay between request retry attempts.
+	backoffPolicy types.BackoffPolicy
 }
 
 // NewHTTPSender creates a new Sender that uses HTTP to send messages
@@ -233,15 +236,24 @@ func (h *HTTPSender) sendRequestWithRetries(ctx context.Context) (*http.Response
 	}
 
 	// Repeatedly try requests with a backoff strategy.
-	infiniteBackoff := backoff.NewExponentialBackOff()
-	// Make backoff run forever.
-	infiniteBackoff.MaxElapsedTime = 0
+	var bpolicy types.BackoffPolicy
+	if h.backoffPolicy != nil {
+		bpolicy = h.backoffPolicy
+	} else {
+		b := backoff.NewExponentialBackOff()
+		b.MaxElapsedTime = 0
+		bpolicy = b
+	}
 
 	interval := time.Duration(0)
 
 	for {
 		timer := time.NewTimer(interval)
-		interval = infiniteBackoff.NextBackOff()
+		next := bpolicy.NextBackOff()
+		if next < 0 {
+			next = backoff.DefaultMaxInterval
+		}
+		interval = next
 
 		select {
 		case <-timer.C:
@@ -458,6 +470,11 @@ func (h *HTTPSender) SetPollingInterval(duration time.Duration) {
 // Should not be called concurrently with Run.
 func (h *HTTPSender) EnableCompression() {
 	h.compressionEnabled = true
+}
+
+// SetBackoffPolicy sets the backoff policy used when retrying failed requests.
+func (h *HTTPSender) SetBackoffPolicy(p types.BackoffPolicy) {
+	h.backoffPolicy = p
 }
 
 func (h *HTTPSender) SetMaxMessageSize(maxMessageSize int64) {

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -71,8 +71,9 @@ type HTTPSender struct {
 	// Processor to handle received messages.
 	receiveProcessor receivedProcessor
 
-	// backoffPolicy controls the delay between request retry attempts.
-	backoffPolicy types.BackoffPolicy
+	// backoffPolicy returns a fresh policy controlling the delay between
+	// request retry attempts for each request sequence.
+	backoffPolicy types.BackoffPolicyFunc
 }
 
 // NewHTTPSender creates a new Sender that uses HTTP to send messages
@@ -238,7 +239,7 @@ func (h *HTTPSender) sendRequestWithRetries(ctx context.Context) (*http.Response
 	// Repeatedly try requests with a backoff strategy.
 	var bpolicy types.BackoffPolicy
 	if h.backoffPolicy != nil {
-		bpolicy = h.backoffPolicy
+		bpolicy = h.backoffPolicy()
 	} else {
 		b := backoff.NewExponentialBackOff()
 		b.MaxElapsedTime = 0
@@ -472,8 +473,9 @@ func (h *HTTPSender) EnableCompression() {
 	h.compressionEnabled = true
 }
 
-// SetBackoffPolicy sets the backoff policy used when retrying failed requests.
-func (h *HTTPSender) SetBackoffPolicy(p types.BackoffPolicy) {
+// SetBackoffPolicy sets the factory that produces a fresh backoff policy for
+// each request retry sequence.
+func (h *HTTPSender) SetBackoffPolicy(p types.BackoffPolicyFunc) {
 	h.backoffPolicy = p
 }
 

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -946,16 +946,16 @@ func TestHTTPSenderUsesBackoffPolicy(t *testing.T) {
 }
 
 // TestHTTPSenderBackoffPolicyNegativeInterval verifies that a BackoffPolicy
-// returning a negative value (the backoff.Stop sentinel) does not terminate the
-// retry loop; the client falls back to a default interval and only stops when
-// the context is cancelled.
+// returning a negative value terminates the retry loop with an error instead of
+// retrying.
 func TestHTTPSenderBackoffPolicyNegativeInterval(t *testing.T) {
 	policy := &mockBackoffPolicy{interval: -1}
 
 	srv := StartMockServer(t)
 	t.Cleanup(srv.Close)
 	srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
-		// Always return 503 so the loop keeps retrying.
+		// Always return 503 so the loop would keep retrying if not for the
+		// negative backoff.
 		w.WriteHeader(http.StatusServiceUnavailable)
 	})
 
@@ -963,14 +963,12 @@ func TestHTTPSenderBackoffPolicyNegativeInterval(t *testing.T) {
 	sender.SetBackoffPolicy(func() types.BackoffPolicy { return policy })
 	sender.callbacks.SetDefaults()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
-
-	_, err := sender.sendRequestWithRetries(ctx)
-	// The loop must exit due to context cancellation, not a premature stop caused
-	// by the negative policy return value.
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.GreaterOrEqual(t, policy.calls.Load(), int64(1))
+	_, err := sender.sendRequestWithRetries(context.Background())
+	// The loop must exit immediately with an error because the policy returned a
+	// negative interval.
+	require.Error(t, err)
+	assert.EqualError(t, err, "invalid backoff policy time")
+	assert.Equal(t, int64(1), policy.calls.Load())
 }
 
 // TestHTTPSenderCenkaltiBackoffWithCustomValues verifies that a cenkalti/backoff

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -1012,6 +1012,65 @@ func TestHTTPSenderCenkaltiBackoffWithCustomValues(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, initialInterval)
 }
 
+// TestHTTPSenderBackoffPolicyFuncFreshPerSequence verifies that the
+// BackoffPolicyFunc is invoked once per request sequence, so each sequence gets
+// a fresh policy instance rather than reusing an already advanced one.
+func TestHTTPSenderBackoffPolicyFuncFreshPerSequence(t *testing.T) {
+	var mu sync.Mutex
+	var policies []*mockBackoffPolicy
+	factory := func() types.BackoffPolicy {
+		mu.Lock()
+		defer mu.Unlock()
+		p := &mockBackoffPolicy{interval: 0}
+		policies = append(policies, p)
+		return p
+	}
+
+	var requestCount atomic.Int64
+	srv := StartMockServer(t)
+	t.Cleanup(srv.Close)
+	srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
+		// Fail the first attempt of each sequence to force one retry, then succeed.
+		if requestCount.Add(1)%2 == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	sender := setupTestSender(t, "http://"+srv.Endpoint)
+	sender.SetBackoffPolicy(factory)
+	sender.callbacks.SetDefaults()
+
+	// Run two independent request sequences. prepareRequest consumes the pending
+	// message, so queue a fresh one before each sequence.
+	for range 2 {
+		sender.NextMessage().Update(func(msg *protobufs.AgentToServer) {
+			msg.AgentDescription = &protobufs.AgentDescription{
+				IdentifyingAttributes: []*protobufs.KeyValue{{
+					Key: "service.name",
+					Value: &protobufs.AnyValue{
+						Value: &protobufs.AnyValue_StringValue{StringValue: "test-service"},
+					},
+				}},
+			}
+		})
+		resp, err := sender.sendRequestWithRetries(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// The func must have been called once per sequence.
+	require.Len(t, policies, 2, "backoffFunc must be invoked once per request sequence")
+	// Each sequence must use a distinct, freshly created policy instance.
+	assert.NotSame(t, policies[0], policies[1], "each sequence must use a distinct policy instance")
+	// Each fresh policy must have been consulted during its own sequence.
+	assert.GreaterOrEqual(t, policies[0].calls.Load(), int64(1))
+	assert.GreaterOrEqual(t, policies[1].calls.Load(), int64(1))
+}
+
 func TestHTTPSenderOpAMPInstanceUIDHeader(t *testing.T) {
 	// Create instance UID
 	uidBytes := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -902,6 +903,113 @@ func setupTestSender(_ *testing.T, url string) *HTTPSender {
 	})
 	sender.url = url
 	return sender
+}
+
+// mockBackoffPolicy is a BackoffPolicy that returns a fixed interval and records
+// call count. Used in tests.
+type mockBackoffPolicy struct {
+	interval time.Duration
+	calls    atomic.Int64
+}
+
+func (p *mockBackoffPolicy) NextBackOff() time.Duration {
+	p.calls.Add(1)
+	return p.interval
+}
+
+// TestHTTPSenderUsesBackoffPolicy verifies that a custom BackoffPolicy is
+// consulted before every request attempt, including retries.
+func TestHTTPSenderUsesBackoffPolicy(t *testing.T) {
+	policy := &mockBackoffPolicy{interval: 0}
+
+	var requestCount atomic.Int64
+	srv := StartMockServer(t)
+	t.Cleanup(srv.Close)
+	srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
+		// Fail the first request to trigger one retry.
+		if requestCount.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	sender := setupTestSender(t, "http://"+srv.Endpoint)
+	sender.SetBackoffPolicy(policy)
+	sender.callbacks.SetDefaults()
+
+	resp, err := sender.sendRequestWithRetries(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// Policy is called before each attempt: once before the 503 and once before the 200.
+	assert.GreaterOrEqual(t, policy.calls.Load(), int64(2))
+}
+
+// TestHTTPSenderBackoffPolicyNegativeInterval verifies that a BackoffPolicy
+// returning a negative value (the backoff.Stop sentinel) does not terminate the
+// retry loop; the client falls back to a default interval and only stops when
+// the context is cancelled.
+func TestHTTPSenderBackoffPolicyNegativeInterval(t *testing.T) {
+	policy := &mockBackoffPolicy{interval: -1}
+
+	srv := StartMockServer(t)
+	t.Cleanup(srv.Close)
+	srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
+		// Always return 503 so the loop keeps retrying.
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	sender := setupTestSender(t, "http://"+srv.Endpoint)
+	sender.SetBackoffPolicy(policy)
+	sender.callbacks.SetDefaults()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_, err := sender.sendRequestWithRetries(ctx)
+	// The loop must exit due to context cancellation, not a premature stop caused
+	// by the negative policy return value.
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.GreaterOrEqual(t, policy.calls.Load(), int64(1))
+}
+
+// TestHTTPSenderCenkaltiBackoffWithCustomValues verifies that a cenkalti/backoff
+// *ExponentialBackOff configured with custom values satisfies BackoffPolicy and
+// that the custom intervals are actually respected during retries.
+func TestHTTPSenderCenkaltiBackoffWithCustomValues(t *testing.T) {
+	const initialInterval = 50 * time.Millisecond
+	b := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(initialInterval),
+		backoff.WithRandomizationFactor(0), // deterministic intervals for assertions
+		backoff.WithMultiplier(2.0),
+		backoff.WithMaxInterval(500*time.Millisecond),
+		backoff.WithMaxElapsedTime(0), // retry indefinitely
+	)
+
+	var requestCount atomic.Int64
+	srv := StartMockServer(t)
+	t.Cleanup(srv.Close)
+	srv.SetOnRequest(func(w http.ResponseWriter, r *http.Request) {
+		if requestCount.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	sender := setupTestSender(t, "http://"+srv.Endpoint)
+	sender.SetBackoffPolicy(b)
+	sender.callbacks.SetDefaults()
+
+	start := time.Now()
+	resp, err := sender.sendRequestWithRetries(context.Background())
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(2), requestCount.Load())
+	// The retry waited for at least the configured initial interval.
+	assert.GreaterOrEqual(t, elapsed, initialInterval)
 }
 
 func TestHTTPSenderOpAMPInstanceUIDHeader(t *testing.T) {

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -935,7 +935,7 @@ func TestHTTPSenderUsesBackoffPolicy(t *testing.T) {
 	})
 
 	sender := setupTestSender(t, "http://"+srv.Endpoint)
-	sender.SetBackoffPolicy(policy)
+	sender.SetBackoffPolicy(func() types.BackoffPolicy { return policy })
 	sender.callbacks.SetDefaults()
 
 	resp, err := sender.sendRequestWithRetries(context.Background())
@@ -960,7 +960,7 @@ func TestHTTPSenderBackoffPolicyNegativeInterval(t *testing.T) {
 	})
 
 	sender := setupTestSender(t, "http://"+srv.Endpoint)
-	sender.SetBackoffPolicy(policy)
+	sender.SetBackoffPolicy(func() types.BackoffPolicy { return policy })
 	sender.callbacks.SetDefaults()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -998,7 +998,7 @@ func TestHTTPSenderCenkaltiBackoffWithCustomValues(t *testing.T) {
 	})
 
 	sender := setupTestSender(t, "http://"+srv.Endpoint)
-	sender.SetBackoffPolicy(b)
+	sender.SetBackoffPolicy(func() types.BackoffPolicy { return b })
 	sender.callbacks.SetDefaults()
 
 	start := time.Now()

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -13,7 +13,6 @@ import (
 // before the next one.
 type BackoffPolicy interface {
 	// NextBackOff returns the duration to wait before the next retry.
-	// A negative return value causes the client to use the defaultMaxInterval interval.
 	NextBackOff() time.Duration
 }
 

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -13,8 +13,7 @@ import (
 // determine how long to wait before the next one.
 //
 // A nil BackoffPolicy causes the client to use a default exponential backoff
-// that retries indefinitely (initial interval 500ms, multiplier 1.5, max
-// interval 60s, no elapsed-time limit).
+// that retries indefinitely.
 type BackoffPolicy interface {
 	// NextBackOff returns the duration to wait before the next retry.
 	// A negative return value causes the client to use the defaultMaxInterval interval.

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -9,16 +9,17 @@ import (
 )
 
 // BackoffPolicy controls the delay between consecutive connection or request
-// retry attempts. The client calls NextBackOff after each failed attempt to
-// determine how long to wait before the next one.
-//
-// A nil BackoffPolicy causes the client to use a default exponential backoff
-// that retries indefinitely.
+// retry attempts. The client calls NextBackOff to determine how long to wait
+// before the next one.
 type BackoffPolicy interface {
 	// NextBackOff returns the duration to wait before the next retry.
 	// A negative return value causes the client to use the defaultMaxInterval interval.
 	NextBackOff() time.Duration
 }
+
+// BackoffPolicyFunc returns a fresh BackoffPolicy. The client invokes it at
+// the start of each retry sequence.
+type BackoffPolicyFunc func() BackoffPolicy
 
 // StartSettings defines the parameters for starting the OpAMP Client.
 type StartSettings struct {
@@ -102,8 +103,11 @@ type StartSettings struct {
 	// If specified a minimum value of 1s will be enforced.
 	DownloadReporterInterval *time.Duration
 
-	// BackoffPolicy controls the delay between consecutive retry attempts when
-	// a connection (WebSocket) or request (HTTP) fails. If nil, a default
-	// exponential backoff is used. See BackoffPolicy for details.
-	BackoffPolicy BackoffPolicy
+	// Optional BackoffPolicy returns a fresh policy controlling the delay between
+	// consecutive retry attempts when a connection (WebSocket) or request
+	// (HTTP) fails. It is invoked at the start of each retry sequence, so every
+	// sequence begins from the returned policy's initial state. If nil, a
+	// default exponential backoff is used that retries indefinitely.
+	// See BackoffPolicy and BackoffPolicyFunc for details.
+	BackoffPolicy BackoffPolicyFunc
 }

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -17,7 +17,7 @@ import (
 // interval 60s, no elapsed-time limit).
 type BackoffPolicy interface {
 	// NextBackOff returns the duration to wait before the next retry.
-	// A negative return value causes the client to reuse the previous interval.
+	// A negative return value causes the client to use the defaultMaxInterval interval.
 	NextBackOff() time.Duration
 }
 

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -5,9 +5,21 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
+
+// BackoffPolicy controls the delay between consecutive connection or request
+// retry attempts. The client calls NextBackOff after each failed attempt to
+// determine how long to wait before the next one.
+//
+// A nil BackoffPolicy causes the client to use a default exponential backoff
+// that retries indefinitely (initial interval 500ms, multiplier 1.5, max
+// interval 60s, no elapsed-time limit).
+type BackoffPolicy interface {
+	// NextBackOff returns the duration to wait before the next retry.
+	// A negative return value causes the client to reuse the previous interval.
+	NextBackOff() time.Duration
+}
 
 // StartSettings defines the parameters for starting the OpAMP Client.
 type StartSettings struct {
@@ -91,6 +103,8 @@ type StartSettings struct {
 	// If specified a minimum value of 1s will be enforced.
 	DownloadReporterInterval *time.Duration
 
-	// Optional ExponentialBackOffOpts to pass options to exponential backoff retries
-	ExponentialBackOffOpts []backoff.ExponentialBackOffOpts
+	// BackoffPolicy controls the delay between consecutive retry attempts when
+	// a connection (WebSocket) or request (HTTP) fails. If nil, a default
+	// exponential backoff is used. See BackoffPolicy for details.
+	BackoffPolicy BackoffPolicy
 }

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/open-telemetry/opamp-go/protobufs"
 )
 
@@ -77,4 +78,7 @@ type StartSettings struct {
 	// If nil, the default reporter interval (10s) will be used.
 	// If specified a minimum value of 1s will be enforced.
 	DownloadReporterInterval *time.Duration
+
+	// Optional ExponentialBackOffOpts to pass options to exponential backoff retries
+	ExponentialBackOffOpts []backoff.ExponentialBackOffOpts
 }

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -61,6 +61,9 @@ type wsClient struct {
 	// connection. responseChain should only be referred to by the goroutine that
 	// runs tryConnectOnce and its synchronous callees.
 	responseChain []*http.Response
+
+	// exponentialBackOffOpts is used to pass options for exponential backoff retries
+	exponentialBackOffOpts []backoff.ExponentialBackOffOpts
 }
 
 // NewWebSocket creates a new OpAMP Client that uses WebSocket transport.
@@ -120,6 +123,8 @@ func (c *wsClient) Start(ctx context.Context, settings types.StartSettings) erro
 	c.getHeader = func() http.Header {
 		return headerFunc(baseHeader.Clone())
 	}
+
+	c.exponentialBackOffOpts = settings.ExponentialBackOffOpts
 
 	c.common.StartConnectAndRun(c.runUntilStopped)
 
@@ -297,7 +302,7 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (retryAfter sharedinterna
 // Continuously try until connected. Will return nil when successfully
 // connected. Will return error if it is cancelled via context.
 func (c *wsClient) ensureConnected(ctx context.Context) error {
-	infiniteBackoff := backoff.NewExponentialBackOff()
+	infiniteBackoff := backoff.NewExponentialBackOff(c.exponentialBackOffOpts...)
 
 	// Make ticker run forever.
 	infiniteBackoff.MaxElapsedTime = 0

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -65,8 +65,9 @@ type wsClient struct {
 	// runs tryConnectOnce and its synchronous callees.
 	responseChain []*http.Response
 
-	// backoffPolicy controls the delay between connection retry attempts.
-	backoffPolicy types.BackoffPolicy
+	// backoffPolicy returns a fresh policy controlling the delay between
+	// connection retry attempts for each connect sequence.
+	backoffPolicy types.BackoffPolicyFunc
 }
 
 // NewWebSocket creates a new OpAMP Client that uses WebSocket transport.
@@ -312,7 +313,7 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (retryAfter sharedinterna
 func (c *wsClient) ensureConnected(ctx context.Context) error {
 	var bpolicy types.BackoffPolicy
 	if c.backoffPolicy != nil {
-		bpolicy = c.backoffPolicy
+		bpolicy = c.backoffPolicy()
 	} else {
 		b := backoff.NewExponentialBackOff()
 		b.MaxElapsedTime = 0

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -65,8 +65,8 @@ type wsClient struct {
 	// runs tryConnectOnce and its synchronous callees.
 	responseChain []*http.Response
 
-	// exponentialBackOffOpts is used to pass options for exponential backoff retries
-	exponentialBackOffOpts []backoff.ExponentialBackOffOpts
+	// backoffPolicy controls the delay between connection retry attempts.
+	backoffPolicy types.BackoffPolicy
 }
 
 // NewWebSocket creates a new OpAMP Client that uses WebSocket transport.
@@ -129,7 +129,7 @@ func (c *wsClient) Start(ctx context.Context, settings types.StartSettings) erro
 		return headerFunc(baseHeader.Clone())
 	}
 
-	c.exponentialBackOffOpts = settings.ExponentialBackOffOpts
+	c.backoffPolicy = settings.BackoffPolicy
 
 	c.common.StartConnectAndRun(c.runUntilStopped)
 
@@ -310,16 +310,24 @@ func (c *wsClient) tryConnectOnce(ctx context.Context) (retryAfter sharedinterna
 // Continuously try until connected. Will return nil when successfully
 // connected. Will return error if it is cancelled via context.
 func (c *wsClient) ensureConnected(ctx context.Context) error {
-	infiniteBackoff := backoff.NewExponentialBackOff(c.exponentialBackOffOpts...)
-
-	// Make ticker run forever.
-	infiniteBackoff.MaxElapsedTime = 0
+	var bpolicy types.BackoffPolicy
+	if c.backoffPolicy != nil {
+		bpolicy = c.backoffPolicy
+	} else {
+		b := backoff.NewExponentialBackOff()
+		b.MaxElapsedTime = 0
+		bpolicy = b
+	}
 
 	interval := time.Duration(0)
 
 	for {
 		timer := time.NewTimer(interval)
-		interval = infiniteBackoff.NextBackOff()
+		next := bpolicy.NextBackOff()
+		if next < 0 {
+			next = backoff.DefaultMaxInterval
+		}
+		interval = next
 
 		select {
 		case <-timer.C:

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -326,7 +326,9 @@ func (c *wsClient) ensureConnected(ctx context.Context) error {
 		timer := time.NewTimer(interval)
 		next := bpolicy.NextBackOff()
 		if next < 0 {
-			next = backoff.DefaultMaxInterval
+			err := errors.New("invalid backoff policy time")
+			c.lastInternalErr.Store(&err)
+			return err
 		}
 		interval = next
 

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -1228,7 +1228,7 @@ func TestWSClientBackoffPolicyDuringReconnect(t *testing.T) {
 
 	settings := types.StartSettings{
 		OpAMPServerURL: "ws://" + srv.Endpoint,
-		BackoffPolicy:  policy,
+		BackoffPolicy:  func() types.BackoffPolicy { return policy },
 	}
 	client := NewWebSocket(nil)
 	startClient(t, settings, client)
@@ -1266,7 +1266,7 @@ func TestWSClientBackoffPolicyNegativeInterval(t *testing.T) {
 
 	settings := types.StartSettings{
 		OpAMPServerURL: "ws://" + srv.Endpoint,
-		BackoffPolicy:  policy,
+		BackoffPolicy:  func() types.BackoffPolicy { return policy },
 	}
 	client := NewWebSocket(nil)
 	startClient(t, settings, client)

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -1212,3 +1212,69 @@ func TestWSClientUseHTTPProxy(t *testing.T) {
 	err := client.Stop(context.Background())
 	assert.NoError(t, err)
 }
+
+// TestWSClientBackoffPolicyDuringReconnect verifies that the BackoffPolicy is
+// consulted during reconnection after a dropped connection.
+func TestWSClientBackoffPolicyDuringReconnect(t *testing.T) {
+	policy := &mockBackoffPolicy{interval: 1 * time.Millisecond}
+
+	srv := internal.StartMockServer(t)
+	t.Cleanup(srv.Close)
+
+	var serverConn atomic.Value
+	srv.SetOnWSConnect(func(c *websocket.Conn) {
+		serverConn.Store(c)
+	})
+
+	settings := types.StartSettings{
+		OpAMPServerURL: "ws://" + srv.Endpoint,
+		BackoffPolicy:  policy,
+	}
+	client := NewWebSocket(nil)
+	startClient(t, settings, client)
+
+	// Wait for the initial connection.
+	eventually(t, func() bool { return serverConn.Load() != nil })
+
+	callsAfterConnect := policy.calls.Load()
+
+	// Drop the server-side connection to trigger a client reconnect.
+	serverConn.Load().(*websocket.Conn).Close()
+
+	// The client must call the policy again during its reconnection attempt.
+	eventually(t, func() bool {
+		return policy.calls.Load() > callsAfterConnect
+	})
+
+	err := client.Stop(context.Background())
+	assert.NoError(t, err)
+}
+
+// TestWSClientBackoffPolicyNegativeInterval verifies that a BackoffPolicy
+// returning a negative value does not prevent connection; the client falls back
+// to a default interval and still connects.
+func TestWSClientBackoffPolicyNegativeInterval(t *testing.T) {
+	policy := &mockBackoffPolicy{interval: -1}
+
+	srv := internal.StartMockServer(t)
+	t.Cleanup(srv.Close)
+
+	var connected atomic.Bool
+	srv.SetOnWSConnect(func(c *websocket.Conn) {
+		connected.Store(true)
+	})
+
+	settings := types.StartSettings{
+		OpAMPServerURL: "ws://" + srv.Endpoint,
+		BackoffPolicy:  policy,
+	}
+	client := NewWebSocket(nil)
+	startClient(t, settings, client)
+
+	// Client must connect and the policy must have been called.
+	eventually(t, func() bool { return connected.Load() })
+	assert.GreaterOrEqual(t, policy.calls.Load(), int64(1))
+
+	err := client.Stop(context.Background())
+	assert.NoError(t, err)
+}

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -1315,8 +1315,8 @@ func TestWSClientBackoffPolicyFuncFreshPerConnect(t *testing.T) {
 }
 
 // TestWSClientBackoffPolicyNegativeInterval verifies that a BackoffPolicy
-// returning a negative value does not prevent connection; the client falls back
-// to a default interval and still connects.
+// returning a negative value prevents connection; the client errors out instead
+// of retrying.
 func TestWSClientBackoffPolicyNegativeInterval(t *testing.T) {
 	policy := &mockBackoffPolicy{interval: -1}
 
@@ -1335,9 +1335,14 @@ func TestWSClientBackoffPolicyNegativeInterval(t *testing.T) {
 	client := NewWebSocket(nil)
 	startClient(t, settings, client)
 
-	// Client must connect and the policy must have been called.
-	eventually(t, func() bool { return connected.Load() })
+	// The negative interval must surface as an internal error and the client
+	// must never connect.
+	eventually(t, func() bool { return client.lastInternalErr.Load() != nil })
+	assert.False(t, connected.Load())
 	assert.GreaterOrEqual(t, policy.calls.Load(), int64(1))
+	if errPtr := client.lastInternalErr.Load(); assert.NotNil(t, errPtr) {
+		assert.EqualError(t, *errPtr, "invalid backoff policy time")
+	}
 
 	err := client.Stop(context.Background())
 	assert.NoError(t, err)

--- a/client/wsclient_test.go
+++ b/client/wsclient_test.go
@@ -1250,6 +1250,70 @@ func TestWSClientBackoffPolicyDuringReconnect(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestWSClientBackoffPolicyFuncFreshPerConnect verifies that the
+// BackoffPolicyFunc is invoked again for each connect sequence, so a reconnect
+// obtains a fresh policy instance rather than reusing the already advanced one
+// from the previous connect.
+func TestWSClientBackoffPolicyFuncFreshPerConnect(t *testing.T) {
+	var mu sync.Mutex
+	var policies []*mockBackoffPolicy
+	factory := func() types.BackoffPolicy {
+		mu.Lock()
+		defer mu.Unlock()
+		p := &mockBackoffPolicy{interval: 1 * time.Millisecond}
+		policies = append(policies, p)
+		return p
+	}
+
+	srv := internal.StartMockServer(t)
+	t.Cleanup(srv.Close)
+
+	var serverConn atomic.Value
+	srv.SetOnWSConnect(func(c *websocket.Conn) {
+		serverConn.Store(c)
+	})
+
+	settings := types.StartSettings{
+		OpAMPServerURL: "ws://" + srv.Endpoint,
+		BackoffPolicy:  factory,
+	}
+	client := NewWebSocket(nil)
+	startClient(t, settings, client)
+
+	// Wait for the initial connection: the func must have produced one policy.
+	eventually(t, func() bool { return serverConn.Load() != nil })
+
+	mu.Lock()
+	firstCount := len(policies)
+	mu.Unlock()
+	require.GreaterOrEqual(t, firstCount, 1, "func must be invoked for the initial connect")
+
+	// Drop the server-side connection to trigger a client reconnect.
+	serverConn.Load().(*websocket.Conn).Close()
+
+	// The reconnect must invoke the func again, producing a new policy.
+	eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(policies) > firstCount
+	})
+
+	err := client.Stop(context.Background())
+	assert.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Every produced policy must be a distinct instance (fresh state per connect).
+	seen := make(map[*mockBackoffPolicy]struct{}, len(policies))
+	for _, p := range policies {
+		_, dup := seen[p]
+		assert.False(t, dup, "factory returned the same policy instance more than once")
+		seen[p] = struct{}{}
+		// Each fresh policy must have been consulted by its own connect sequence.
+		assert.GreaterOrEqual(t, p.calls.Load(), int64(1))
+	}
+}
+
 // TestWSClientBackoffPolicyNegativeInterval verifies that a BackoffPolicy
 // returning a negative value does not prevent connection; the client falls back
 // to a default interval and still connects.


### PR DESCRIPTION
Exposing BackoffPolicy in StartSettings in to allow control over reconnects and retries to the user.