### PR TITLE
Improve example server agent list

### DIFF
--- a/internal/examples/html/html/root.html
+++ b/internal/examples/html/html/root.html
@@ -10,10 +10,18 @@
 
 <table width=100% border="1" style="border-collapse: collapse">
     <tr>
+        <th>Name</th>
+        <th>Version</th>
+        <th>Health</th>
+        <th>Last seen</th>
         <th>Instance ID</th>
     </tr>
 {{ range . }}
     <tr>
+        <td>{{ .ServiceName }}</td>
+        <td>{{ .ServiceVersion }}</td>
+        <td>{{ .HealthStatus }}</td>
+        <td>{{ .LastSeen }}</td>
         <td><a href="agent?instanceid={{ .InstanceIdStr }}">{{ .InstanceIdStr }}</a></td>
     </tr>
 {{ end }}

--- a/internal/examples/server/data/agent.go
+++ b/internal/examples/server/data/agent.go
@@ -43,6 +43,9 @@ type Agent struct {
 	// The time when the agent has started. Valid only if Status.Health.Up==true
 	StartedAt time.Time
 
+	// The time when the agent last reported status.
+	LastSeenAt time.Time
+
 	// Effective config reported by the Agent.
 	EffectiveConfig string
 
@@ -86,6 +89,83 @@ func NewAgent(
 	return agent
 }
 
+func (agent *Agent) ServiceName() string {
+	return valueOrPlaceholder(agent.displayAttribute("service.name"))
+}
+
+func (agent *Agent) ServiceVersion() string {
+	return valueOrPlaceholder(agent.displayAttribute("service.version"))
+}
+
+func (agent *Agent) HealthStatus() string {
+	if agent.Status == nil || agent.Status.Health == nil {
+		return "Unknown"
+	}
+
+	if agent.Status.Health.Healthy {
+		return "Up"
+	}
+
+	return "Down"
+}
+
+func (agent *Agent) LastSeen() string {
+	if agent.LastSeenAt.IsZero() {
+		return ""
+	}
+
+	return agent.LastSeenAt.Format(time.RFC3339)
+}
+
+func (agent *Agent) displayAttribute(key string) string {
+	if agent.Status == nil || agent.Status.AgentDescription == nil {
+		return ""
+	}
+
+	for _, attr := range agent.Status.AgentDescription.IdentifyingAttributes {
+		if attr.Key == key {
+			return formatAnyValue(attr.Value)
+		}
+	}
+
+	for _, attr := range agent.Status.AgentDescription.NonIdentifyingAttributes {
+		if attr.Key == key {
+			return formatAnyValue(attr.Value)
+		}
+	}
+
+	return ""
+}
+
+func formatAnyValue(value *protobufs.AnyValue) string {
+	if value == nil {
+		return ""
+	}
+
+	switch v := value.GetValue().(type) {
+	case *protobufs.AnyValue_StringValue:
+		return v.StringValue
+	case *protobufs.AnyValue_BoolValue:
+		return fmt.Sprint(v.BoolValue)
+	case *protobufs.AnyValue_IntValue:
+		return fmt.Sprint(v.IntValue)
+	case *protobufs.AnyValue_DoubleValue:
+		return fmt.Sprint(v.DoubleValue)
+	case *protobufs.AnyValue_BytesValue:
+		return fmt.Sprintf("%x", v.BytesValue)
+	default:
+		return value.String()
+	}
+}
+
+func valueOrPlaceholder(value string) string {
+	if value == "" {
+		return "Unknown"
+	}
+
+	return value
+}
+
 // CloneReadonly returns a copy of the Agent that is safe to read.
 // Functions that modify the Agent should not be called on the cloned copy.
 func (agent *Agent) CloneReadonly() *Agent {
@@ -99,6 +179,7 @@ func (agent *Agent) CloneReadonly() *Agent {
 		CustomInstanceConfig:        agent.CustomInstanceConfig,
 		remoteConfig:                proto.Clone(agent.remoteConfig).(*protobufs.AgentRemoteConfig),
 		StartedAt:                   agent.StartedAt,
+		LastSeenAt:                  agent.LastSeenAt,
 		ClientCert:                  agent.ClientCert,
 		ClientCertOfferError:        agent.ClientCertOfferError,
 		ClientCertSha256Fingerprint: agent.ClientCertSha256Fingerprint,
@@ -114,6 +195,7 @@ func (agent *Agent) UpdateStatus(
 	response *protobufs.ServerToAgent,
 ) {
 	agent.mux.Lock()
+	agent.LastSeenAt = time.Now().UTC()
 
 	agent.processStatusUpdate(statusMsg, response)
 

--- a/internal/examples/server/data/agent.go
+++ b/internal/examples/server/data/agent.go
@@ -154,7 +154,8 @@ func formatAnyValue(value *protobufs.AnyValue) string {
 	case *protobufs.AnyValue_BytesValue:
 		return fmt.Sprintf("%x", v.BytesValue)
 	default:
-		return value.String()
+		// nil oneof (unset value) - return empty string rather than the proto text representation.
+		return ""
 	}
 }
 
@@ -166,6 +167,18 @@ func valueOrPlaceholder(value string) string {
 	return value
 }
 
+// cloneProto safely clones a proto message, returning nil if the input is nil
+// (avoiding the nil type assertion panic that proto.Clone(nil).(*T) would cause).
+func cloneProto[T any, PT interface {
+	proto.Message
+	*T
+}](m PT) PT {
+	if m == nil {
+		return nil
+	}
+	return proto.Clone(m).(PT)
+}
+
 // CloneReadonly returns a copy of the Agent that is safe to read.
 // Functions that modify the Agent should not be called on the cloned copy.
 func (agent *Agent) CloneReadonly() *Agent {
@@ -174,10 +187,10 @@ func (agent *Agent) CloneReadonly() *Agent {
 	return &Agent{
 		InstanceId:                  agent.InstanceId,
 		InstanceIdStr:               uuid.UUID(agent.InstanceId).String(),
-		Status:                      proto.Clone(agent.Status).(*protobufs.AgentToServer),
+		Status:                      cloneProto[protobufs.AgentToServer](agent.Status),
 		EffectiveConfig:             agent.EffectiveConfig,
 		CustomInstanceConfig:        agent.CustomInstanceConfig,
-		remoteConfig:                proto.Clone(agent.remoteConfig).(*protobufs.AgentRemoteConfig),
+		remoteConfig:                cloneProto[protobufs.AgentRemoteConfig](agent.remoteConfig),
 		StartedAt:                   agent.StartedAt,
 		LastSeenAt:                  agent.LastSeenAt,
 		ClientCert:                  agent.ClientCert,

--- a/internal/examples/server/uisrv/ui.go
+++ b/internal/examples/server/uisrv/ui.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"text/template"
+	"html/template"
 	"time"
 
 	"github.com/google/uuid"

--- a/internal/examples/server/uisrv/ui.go
+++ b/internal/examples/server/uisrv/ui.go
@@ -2,11 +2,11 @@ package uisrv
 
 import (
 	"context"
+	"html/template"
 	"log"
 	"net/http"
 	"net/url"
 	"path"
-	"html/template"
 	"time"
 
 	"github.com/google/uuid"


### PR DESCRIPTION
Show service name, version, health, and last-seen time in the example server agent list.

Context: this improves the example server UI for the OpenTelemetry Demo OpAMP integration in open-telemetry/opentelemetry-demo#3566.

Screenshot from local test:
<img width="1506" height="471" alt="image" src="https://github.com/user-attachments/assets/e70bfabb-b27a-4120-a09d-8d387cdc1b6b" />
