### PR TITLE
Show agent uptime on example server agent page

### DIFF
--- a/internal/examples/html/html/agent.html
+++ b/internal/examples/html/html/agent.html
@@ -36,6 +36,9 @@
                 <tr>
                     <td>Up since:</td><td>{{ .StartedAt }}</td>
                 </tr>
+                <tr>
+                    <td>Uptime:</td><td>{{ .Uptime }}</td>
+                </tr>
                 {{end}}
                 {{end}}
             </table>

--- a/internal/examples/server/data/agent.go
+++ b/internal/examples/server/data/agent.go
@@ -117,6 +117,16 @@ func (agent *Agent) LastSeen() string {
 	return agent.LastSeenAt.Format(time.RFC3339)
 }
 
+// Uptime returns how long the Agent has been up, computed from the start time
+// it reported in its health status. Valid only while the Agent is healthy.
+func (agent *Agent) Uptime() string {
+	if agent.StartedAt.IsZero() {
+		return ""
+	}
+
+	return time.Since(agent.StartedAt).Truncate(time.Second).String()
+}
+
 func (agent *Agent) displayAttribute(key string) string {
 	if agent.Status == nil || agent.Status.AgentDescription == nil {
 		return ""


### PR DESCRIPTION
Adds an **Uptime** row to the example server's agent detail page, computed from the start time the agent reported in its health status (`current time - StartedAt`), shown only while the agent is healthy — right below the existing "Up since" row.

Makes it easy to see at a glance how long an agent has been up without mentally subtracting timestamps. Complements the agent list improvements from #590.

Example rendering:

```
Up since: 2026-07-05 15:53:15 +0000 UTC
Uptime:   3m44s
```