### PR TITLE
Add -no-tls flag to example server

### DIFF
--- a/internal/examples/server/main.go
+++ b/internal/examples/server/main.go
@@ -17,6 +17,9 @@ func main() {
 	var emitMetrics bool
 	flag.BoolVar(&emitMetrics, "emit-metrics", false, "Emit metrics to stdout.")
 
+	var noTLS bool
+	flag.BoolVar(&noTLS, "no-tls", false, "Serve the OpAMP endpoint without TLS, accepting plaintext (ws://) connections. Useful when testing OpAMP clients that do not support TLS yet.")
+
 	flag.Parse()
 
 	curDir, err := os.Getwd()
@@ -28,7 +31,7 @@ func main() {
 
 	uisrv.Start(curDir)
 	opampSrv := opampsrv.NewServer(&data.AllAgents, emitMetrics)
-	opampSrv.Start()
+	opampSrv.Start(noTLS)
 
 	logger.Println("OpAMP Server running...")
 

--- a/internal/examples/server/opampsrv/opampsrv.go
+++ b/internal/examples/server/opampsrv/opampsrv.go
@@ -50,7 +50,7 @@ func NewServer(agents *data.Agents, emitMetrics bool) *Server {
 	return srv
 }
 
-func (srv *Server) Start() {
+func (srv *Server) Start(noTLS bool) {
 	settings := server.StartSettings{
 		Settings: server.Settings{
 			Callbacks: types.Callbacks{
@@ -75,15 +75,19 @@ func (srv *Server) Start() {
 		ListenEndpoint: "0.0.0.0:4320",
 		HTTPMiddleware: otelhttp.NewMiddleware("/v1/opamp"),
 	}
-	tlsConfig, err := certs.CreateServerTLSConfig(
-		certs.CaCert,
-		certs.ServerCert,
-		certs.ServerKey,
-	)
-	if err != nil {
-		srv.logger.Debugf(context.Background(), "Could not load TLS config, working without TLS: %v", err.Error())
+	if noTLS {
+		srv.logger.Debugf(context.Background(), "TLS disabled by flag, accepting plaintext (ws://) connections")
+	} else {
+		tlsConfig, err := certs.CreateServerTLSConfig(
+			certs.CaCert,
+			certs.ServerCert,
+			certs.ServerKey,
+		)
+		if err != nil {
+			srv.logger.Debugf(context.Background(), "Could not load TLS config, working without TLS: %v", err.Error())
+		}
+		settings.TLSConfig = tlsConfig
 	}
-	settings.TLSConfig = tlsConfig
 
 	if err := srv.opampSrv.Start(settings); err != nil {
 		srv.logger.Errorf(context.Background(), "OpAMP server start fail: %v", err.Error())

--- a/internal/examples/supervisor/supervisor/supervisor_test.go
+++ b/internal/examples/supervisor/supervisor/supervisor_test.go
@@ -38,7 +38,7 @@ func startOpampServer(t *testing.T) {
 	t.Helper()
 
 	opampSrv := opampsrv.NewServer(&data.AllAgents, false)
-	opampSrv.Start()
+	opampSrv.Start(false)
 
 	t.Cleanup(func() {
 		opampSrv.Stop()


### PR DESCRIPTION
Adds a `-no-tls` flag to the example server that serves the OpAMP endpoint without TLS, accepting plaintext (`ws://`) connections. Default behavior is unchanged: TLS stays on unless the flag is passed.

The example server currently always enables TLS (falling back to plaintext only if the embedded certs fail to load), while the example agent already has an escape hatch via its `-endpoint` flag. This adds the symmetric opt-in on the server side.

The main use case is interop-testing OpAMP client implementations that don't support TLS yet — the usual state of a client under development. (Encountered while testing a OTel Arrow df_engine's OpAMP client against this server.)

```
go run ./server -no-tls
```