### PR TITLE
Log OpAMP endpoint and admin UI addresses on example server startup

### DIFF
--- a/internal/examples/server/opampsrv/opampsrv.go
+++ b/internal/examples/server/opampsrv/opampsrv.go
@@ -75,9 +75,7 @@ func (srv *Server) Start(noTLS bool) {
 		ListenEndpoint: "0.0.0.0:4320",
 		HTTPMiddleware: otelhttp.NewMiddleware("/v1/opamp"),
 	}
-	if noTLS {
-		srv.logger.Debugf(context.Background(), "TLS disabled by flag, accepting plaintext (ws://) connections")
-	} else {
+	if !noTLS {
 		tlsConfig, err := certs.CreateServerTLSConfig(
 			certs.CaCert,
 			certs.ServerCert,
@@ -93,6 +91,12 @@ func (srv *Server) Start(noTLS bool) {
 		srv.logger.Errorf(context.Background(), "OpAMP server start fail: %v", err.Error())
 		os.Exit(1)
 	}
+
+	tls := "TLS enabled (use wss:// or https://)"
+	if noTLS {
+		tls = "TLS disabled (use ws:// or http://)"
+	}
+	srv.logger.Debugf(context.Background(), "OpAMP server started, listening at 0.0.0.0:4320/v1/opamp - %s", tls)
 }
 
 func (srv *Server) Stop() {

--- a/internal/examples/server/uisrv/ui.go
+++ b/internal/examples/server/uisrv/ui.go
@@ -39,6 +39,8 @@ func Start(rootDir string) {
 		Handler: mux,
 	}
 	go srv.ListenAndServe()
+
+	logger.Printf("Admin UI started, available at http://localhost:4321")
 }
 
 func Shutdown() {


### PR DESCRIPTION
Surfaces the OpAMP endpoint and admin UI addresses in the example server's startup logs so users know where to connect. The OpAMP endpoint line notes TLS state and that both `ws(s)://` and `http(s)://` transports are served on the same URL.