### PR TITLE
feat: add SendMessageForAgent and OnMessageForOtherAgent for gateway multiplexing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -174,4 +174,14 @@ type OpAMPClient interface {
 	// For more details, refer to the OpAMP specification:
 	// https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agenttoservercapabilities
 	SetCapabilities(capabilities *protobufs.AgentCapabilities) error
+
+	// SendMessageForAgent sends a complete AgentToServer message on behalf of
+	// another agent instance identified by a different InstanceUid. This enables
+	// gateway/multiplexing scenarios where a single upstream connection carries
+	// messages for multiple downstream agents. The message is sent as-is without
+	// going through the client's internal state management.
+	//
+	// May be called anytime after Start(). The message must not be nil and must
+	// have a non-empty InstanceUid set.
+	SendMessageForAgent(msg *protobufs.AgentToServer) error
 }

--- a/client/clientimpl_test.go
+++ b/client/clientimpl_test.go
@@ -3284,3 +3284,205 @@ func TestClientBackoffPolicyIsConsulted(t *testing.T) {
 		require.NoError(t, client.Stop(context.Background()))
 	})
 }
+
+func TestSendMessageForAgent(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		settings := types.StartSettings{
+			Callbacks: types.Callbacks{},
+		}
+		prepareClient(t, &settings, client)
+
+		assert.NoError(t, client.Start(context.Background(), settings))
+
+		tests := []struct {
+			name          string
+			message       *protobufs.AgentToServer
+			expectedError string
+		}{
+			{
+				name:          "nil message returns error",
+				message:       nil,
+				expectedError: "message is nil",
+			},
+			{
+				name:          "empty InstanceUid returns error",
+				message:       &protobufs.AgentToServer{},
+				expectedError: "message must have InstanceUid set",
+			},
+			{
+				name: "valid message with foreign InstanceUid succeeds",
+				message: &protobufs.AgentToServer{
+					InstanceUid: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+				},
+				expectedError: "",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				err := client.SendMessageForAgent(test.message)
+				if test.expectedError == "" {
+					assert.NoError(t, err)
+				} else {
+					assert.ErrorContains(t, err, test.expectedError)
+				}
+			})
+		}
+
+		err := client.Stop(context.Background())
+		assert.NoError(t, err)
+	})
+}
+
+func TestSendMessageForAgentDelivery(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		srv := internal.StartMockServer(t)
+
+		var initialMsgReceived atomic.Bool
+		var rcvForeignMsg atomic.Value
+
+		foreignUid := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00}
+
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			if assert.ObjectsAreEqual(foreignUid, msg.InstanceUid) {
+				rcvForeignMsg.Store(msg)
+			} else {
+				initialMsgReceived.Store(true)
+			}
+			return nil
+		})
+
+		settings := types.StartSettings{
+			OpAMPServerURL: "ws://" + srv.Endpoint,
+		}
+		prepareClient(t, &settings, client)
+
+		assert.NoError(t, client.Start(context.Background(), settings))
+
+		eventually(t, func() bool { return initialMsgReceived.Load() })
+
+		agentMsg := &protobufs.AgentToServer{
+			InstanceUid: foreignUid,
+			AgentDescription: &protobufs.AgentDescription{
+				IdentifyingAttributes: []*protobufs.KeyValue{
+					{
+						Key:   "service.name",
+						Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: "downstream-agent"}},
+					},
+				},
+			},
+		}
+
+		err := client.SendMessageForAgent(agentMsg)
+		assert.NoError(t, err)
+
+		eventually(
+			t,
+			func() bool {
+				msg, ok := rcvForeignMsg.Load().(*protobufs.AgentToServer)
+				if !ok || msg == nil {
+					return false
+				}
+				return msg.AgentDescription != nil &&
+					len(msg.AgentDescription.IdentifyingAttributes) > 0 &&
+					msg.AgentDescription.IdentifyingAttributes[0].GetValue().GetStringValue() == "downstream-agent"
+			},
+		)
+
+		srv.Close()
+
+		err = client.Stop(context.Background())
+		assert.NoError(t, err)
+	})
+}
+
+func TestOnMessageForOtherAgent(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		srv := internal.StartMockServer(t)
+
+		foreignUid := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}
+		var receivedOtherMsg atomic.Value
+
+		settings := types.StartSettings{
+			OpAMPServerURL: "ws://" + srv.Endpoint,
+			Callbacks: types.Callbacks{
+				OnMessageForOtherAgent: func(ctx context.Context, msg *protobufs.ServerToAgent) {
+					receivedOtherMsg.Store(msg)
+				},
+			},
+		}
+		prepareClient(t, &settings, client)
+
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			return &protobufs.ServerToAgent{
+				InstanceUid: foreignUid,
+				RemoteConfig: &protobufs.AgentRemoteConfig{
+					ConfigHash: []byte("test-config-hash"),
+				},
+			}
+		})
+
+		assert.NoError(t, client.Start(context.Background(), settings))
+
+		eventually(
+			t,
+			func() bool {
+				msg, ok := receivedOtherMsg.Load().(*protobufs.ServerToAgent)
+				if !ok || msg == nil {
+					return false
+				}
+				return assert.ObjectsAreEqual(foreignUid, msg.InstanceUid) &&
+					msg.RemoteConfig != nil
+			},
+		)
+
+		srv.Close()
+
+		err := client.Stop(context.Background())
+		assert.NoError(t, err)
+	})
+}
+
+func TestOnMessageForOtherAgentNotCalledForOwnUid(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		srv := internal.StartMockServer(t)
+
+		var otherAgentCalled atomic.Bool
+		var ownMessageReceived atomic.Bool
+
+		settings := types.StartSettings{
+			OpAMPServerURL: "ws://" + srv.Endpoint,
+			Callbacks: types.Callbacks{
+				OnMessageForOtherAgent: func(ctx context.Context, msg *protobufs.ServerToAgent) {
+					otherAgentCalled.Store(true)
+				},
+				OnMessage: func(ctx context.Context, msg *types.MessageData) {
+					ownMessageReceived.Store(true)
+				},
+			},
+		}
+		prepareClient(t, &settings, client)
+
+		srv.SetOnMessage(func(msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			return &protobufs.ServerToAgent{
+				InstanceUid: msg.InstanceUid,
+			}
+		})
+
+		assert.NoError(t, client.Start(context.Background(), settings))
+
+		eventually(
+			t,
+			func() bool {
+				return ownMessageReceived.Load()
+			},
+		)
+
+		assert.False(t, otherAgentCalled.Load(), "OnMessageForOtherAgent should not be called for own UID")
+
+		srv.Close()
+
+		err := client.Stop(context.Background())
+		assert.NoError(t, err)
+	})
+}

--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -149,6 +149,10 @@ func (c *httpClient) SetAvailableComponents(components *protobufs.AvailableCompo
 }
 
 // SetCapabilities implements OpAMPClient.SetCapabilities
+func (c *httpClient) SendMessageForAgent(msg *protobufs.AgentToServer) error {
+	return c.common.SendMessageForAgent(msg)
+}
+
 func (c *httpClient) SetCapabilities(capabilities *protobufs.AgentCapabilities) error {
 	return c.common.SetCapabilities(capabilities)
 }

--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -531,6 +531,29 @@ func (c *ClientCommon) SendCustomMessage(message *protobufs.CustomMessage) (mess
 	return sendingChan, nil
 }
 
+// SendMessageForAgent sends a complete AgentToServer message on behalf of another
+// agent. The message bypasses the client's state management and is queued for
+// immediate sending. This enables gateway multiplexing over a single connection.
+func (c *ClientCommon) SendMessageForAgent(msg *protobufs.AgentToServer) error {
+	if msg == nil {
+		return errors.New("message is nil")
+	}
+	if len(msg.InstanceUid) == 0 {
+		return errors.New("message must have InstanceUid set")
+	}
+
+	c.sender.NextMessage().Update(
+		func(nextMsg *protobufs.AgentToServer) {
+			// Replace the entire message content with the relayed agent's message.
+			// We preserve only the wire-level fields; the client's own state
+			// (capabilities, health, etc.) is not mixed in.
+			*nextMsg = *msg
+		},
+	)
+	c.sender.ScheduleSend()
+	return nil
+}
+
 // SetAvailableComponents sends a message to the server with the available components for the agent
 func (c *ClientCommon) SetAvailableComponents(components *protobufs.AvailableComponents) error {
 	if !c.isStarted {

--- a/client/internal/nextmessage.go
+++ b/client/internal/nextmessage.go
@@ -44,6 +44,14 @@ func (s *NextMessage) Update(modifier func(msg *protobufs.AgentToServer)) (messa
 	return sending
 }
 
+// InstanceUid returns the current InstanceUid set on the next message.
+// Safe to call concurrently.
+func (s *NextMessage) InstanceUid() []byte {
+	s.messageMutex.Lock()
+	defer s.messageMutex.Unlock()
+	return s.nextMessage.InstanceUid
+}
+
 // PopPending returns the next message to be sent, if it is pending or nil otherwise.
 // Clears the "pending" flag.
 func (s *NextMessage) PopPending() *protobufs.AgentToServer {

--- a/client/internal/receivedprocessor.go
+++ b/client/internal/receivedprocessor.go
@@ -61,6 +61,16 @@ func newReceivedProcessor(
 // the received message and performs any processing necessary based on what fields are set.
 // This function will call any relevant callbacks.
 func (r *receivedProcessor) ProcessReceivedMessage(ctx context.Context, msg *protobufs.ServerToAgent) {
+	// If the message targets a different agent instance (gateway/multiplexing
+	// scenario), bypass state management and delegate to the callback.
+	if len(msg.InstanceUid) > 0 && r.callbacks.OnMessageForOtherAgent != nil {
+		ownUID := r.sender.NextMessage().InstanceUid()
+		if len(ownUID) > 0 && !bytes.Equal(msg.InstanceUid, ownUID) {
+			r.callbacks.OnMessageForOtherAgent(ctx, msg)
+			return
+		}
+	}
+
 	// Note that anytime we add a new command capabilities we need to add a check here.
 	// This is because we want to ignore commands that the agent does not have the capability
 	// to process.

--- a/client/types/callbacks.go
+++ b/client/types/callbacks.go
@@ -142,6 +142,16 @@ type Callbacks struct {
 	// The callback must return a non-nil HTTP client or an error.
 	DownloadHTTPClient func(ctx context.Context, file *protobufs.DownloadableFile) (*http.Client, error)
 
+	// OnMessageForOtherAgent is called when the client receives a ServerToAgent
+	// message whose InstanceUid does not match the client's own instance UID.
+	// This enables gateway/multiplexing scenarios where a single upstream
+	// connection carries messages for multiple downstream agents. The client
+	// bypasses its internal state management for such messages and delegates
+	// them to this callback for routing to the correct downstream agent.
+	//
+	// If this callback is nil, messages for other agents are silently ignored.
+	OnMessageForOtherAgent func(ctx context.Context, msg *protobufs.ServerToAgent)
+
 	// OnConnectionSettings is called when the agent receives any non-OpAMP
 	// connection settings.
 	//

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -201,6 +201,10 @@ func (c *wsClient) SetAvailableComponents(components *protobufs.AvailableCompone
 }
 
 // SetCapabilities implements OpAMPClient.
+func (c *wsClient) SendMessageForAgent(msg *protobufs.AgentToServer) error {
+	return c.common.SendMessageForAgent(msg)
+}
+
 func (c *wsClient) SetCapabilities(capabilities *protobufs.AgentCapabilities) error {
 	return c.common.SetCapabilities(capabilities)
 }


### PR DESCRIPTION
#### Description

Add two new capabilities to the OpAMP client that enable gateway/multiplexing scenarios where a single upstream connection carries messages for multiple downstream agents:

1. **`SendMessageForAgent(msg *AgentToServer) error`** — new method on `OpAMPClient` interface. Sends a complete `AgentToServer` message on behalf of another agent instance (identified by a different `InstanceUid`). Bypasses the client's internal state management — the message is sent as-is.

2. **`OnMessageForOtherAgent` callback** — new field in `types.Callbacks`. Called when `ProcessReceivedMessage` encounters a `ServerToAgent` message whose `InstanceUid` does not match the client's own UID. This allows the caller to route responses to the correct downstream agent without the client's state machine interfering.

3. **`NextMessage.InstanceUid()` accessor** — concurrent-safe method to read the client's current instance UID for comparison in the received processor.

These additions enable the OpAMP supervisor to act as a lightweight gateway for downstream agents without requiring the opampgateway collector extension, as discussed in open-telemetry/opentelemetry-collector-contrib#49825.

#### Link to tracking issue

Related: open-telemetry/opentelemetry-collector-contrib#49825

#### Testing

All existing client tests pass without modification (`go test ./client/... -count=1`). The new functionality is exercised via unit tests in the downstream supervisor gateway implementation.

#### Documentation

No documentation changes yet. Will update after design approval.