### PR TITLE
chore: Pin GitHub Action digests to semver

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "config:best-practices",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
This enables `helpers:pinGitHubActionDigestsToSemver` as mentioned in https://github.com/open-telemetry/sig-security/issues/116

Setting is explained at https://docs.renovatebot.com/presets-helpers/

This just brings consistency to the versions specified for github actions.