### PR TITLE
Remove CI caching to fix zizmor cache-poisoning findings

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,32 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  setup-environment:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Setup Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: "go.mod"
-      - name: Setup Go Environment
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Cache Go
-        id: module-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: /home/runner/go/pkg/mod
-          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
-      - name: Install dependencies
-        if: steps.module-cache.outputs.cache-hit != 'true'
-        run: make gomoddownload install-tools # get regular dependencies and tools
-
   build-and-test:
     runs-on: ubuntu-latest
-    needs: [setup-environment]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -44,21 +20,11 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "go.mod"
+          cache: false
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Cache Go
-        id: module-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: /home/runner/go/pkg/mod
-          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
-      - name: Cache Build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: /home/runner/.cache/go-build
-          key: go-build-unittest-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
       - name: Go fmt
         run: |
           make fmt
@@ -68,7 +34,6 @@ jobs:
 
   test-coverage:
     runs-on: ubuntu-latest
-    needs: [setup-environment]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -76,21 +41,11 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: "go.mod"
+          cache: false
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Cache Go
-        id: module-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: /home/runner/go/pkg/mod
-          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-      - name: Cache Build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: /home/runner/.cache/go-build
-          key: go-build-coverage-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests With Coverage
         run: make test-with-cover
       - name: Upload coverage report


### PR DESCRIPTION
Prerequisite for #613, which adopts zizmor. Without this, that PR has to carry a `cache-poisoning` suppression in `.github/zizmor.yml` rather than landing with a clean scan.

`build-and-test.yml` runs on version tags, so zizmor treats it as a workflow that could publish release artifacts and reports 8 `cache-poisoning` findings — 3 for `actions/setup-go` (whose `cache` input defaults to `true`) and 5 for the explicit `actions/cache` steps.

This removes the five `actions/cache` steps and sets `cache: false` on the `setup-go` steps.

[`opentelemetry-collector` addresses the same findings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/.github/workflows/build-and-test.yml) in its own `build-and-test.yml` with `cache: false` plus `lookup-only: true` on the cache steps. Per the [`actions/cache` docs](https://github.com/actions/cache#inputs), `lookup-only` "only checks if cache entry exists and skips download. Does not change save cache behavior" — so those steps still upload caches that are never restored. Removing them gets the same behavior with less configuration.

The trade-off is that CI no longer caches, which is what resolves the finding: a cache that is never restored cannot be poisoned. That is the same trade-off opentelemetry-collector accepted in a much larger repository.

This also drops the `setup-environment` job. Its only purpose was to warm the module cache for the other two jobs; with no cache it passes nothing along. `make gomoddownload` and `make install-tools` were prefetches — the tools are invoked as `go tool -modfile $(TOOLS_MOD) ...`, so the remaining jobs resolve them on demand regardless. `build-and-test` is the only required status check, so this does not affect branch protection.

zizmor 1.29.0: 8 `cache-poisoning` findings → 0.
