### PR TITLE
Use otelbot to push go mod tidy results

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,49 +1,95 @@
 name: go-mod-tidy
+
 on:
-  pull_request_target:
-    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+  push:
     branches:
-      - main
+      - "renovate/**"
+    paths:
+      - "**/go.mod"
+      - "**/go.sum"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
+
 jobs:
-  setup-environment:
-    permissions:
-      contents: write # to allow pushing changes to the branch
+  generate:
     runs-on: ubuntu-latest
-    if: ${{ (github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'renovatebot')) && github.event.pull_request.head.repo.fork == false }}
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
+
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - name: Setup Go Environment
+          cache: false
+
+      - name: Run go mod tidy
+        run: make tidy
+
+      - id: create-patch
+        name: Create patch file
         run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Cache Go
-        id: module-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+          git add -N --ignore-removal -- go.mod go.sum '*/go.mod' '*/go.sum'
+          git diff -- go.mod go.sum '*/go.mod' '*/go.sum' > patch
+          if [ -s patch ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload patch file
+        if: steps.create-patch.outputs.exists == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: /home/runner/go/pkg/mod
-          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
-      - name: Install dependencies
-        if: steps.module-cache.outputs.cache-hit != 'true'
-        run: make gomoddownload
-      - name: Install Tools
-        if: steps.module-cache.outputs.cache-hit != 'true'
-        run: make install-tools
-      - name: go mod tidy, make all
+          path: patch
+          name: patch
+
+  # separate job is just to isolate the OTELBOT_OPAMP_GO_PRIVATE_KEY usage a bit
+  apply:
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Download patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: patch
+          path: ${{ runner.temp }}
+
+      - id: check-patch
+        name: Check patch
+        working-directory: ${{ runner.temp }}
         run: |
-          make tidy && make all
+          if [ -f patch ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: steps.check-patch.outputs.exists == 'true'
+        id: otelbot-token
+        with:
+          client-id: ${{ vars.OTELBOT_OPAMP_GO_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_OPAMP_GO_PRIVATE_KEY }}
+          permission-contents: write
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.check-patch.outputs.exists == 'true'
+        with:
+          token: ${{ steps.otelbot-token.outputs.token }}
+          # zizmor: ignore[artipacked] App credentials are required by the push below.
+          persist-credentials: true
+
+      - name: Apply patch and push
+        if: steps.check-patch.outputs.exists == 'true'
+        env:
+          PATCH: ${{ runner.temp }}/patch
+        run: |
+          git apply "${PATCH}"
+          git add -- go.mod go.sum '*/go.mod' '*/go.sum'
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
-          echo "git diff --exit-code || (git add . && git commit -m \"go mod tidy, make all\" && git push)"
-          git diff --exit-code || (git add . && git commit -m "go mod tidy, make all" && git push)
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
-        with:
-          labels: renovatebot
+          git commit -m "Run go mod tidy"
+          git push


### PR DESCRIPTION
Prerequisite for #613, which adopts zizmor.

`tidy.yml` runs on `pull_request_target`, gates on a spoofable `github.actor` check, and pushes with `GITHUB_TOKEN` — 6 zizmor findings that need a change to the workflow's shape rather than a mechanical fix.

Reworked to follow [`auto-license-report.yml`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/.github/workflows/auto-license-report.yml) in opentelemetry-java-instrumentation, which solves the same problem for the same bot: an unprivileged `generate` job runs `make tidy` and uploads a patch scoped to `go.mod`/`go.sum`, and a separate `apply` job mints an otelbot token, applies the patch, and pushes.

**Bonus:** because the push comes from otelbot rather than `GITHUB_TOKEN`, CI runs on the tidy commit automatically. Today those runs land in `action_required` and a maintainer has to re-run them by hand ([example](https://github.com/open-telemetry/opamp-go/pull/605)).

The `renovatebot` label trigger goes away with `pull_request_target`; the workflow now runs on any Renovate branch touching `go.mod`/`go.sum`. `make all` is dropped, since `build-and-test` already runs it.

zizmor 1.29.0 on `tidy.yml`: 8 findings → 0.
