### PR TITLE
Let Renovate manage internal/examples

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "ignorePaths": [],
   "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
Unrelated to the zizmor work — just happened to run into it in case you want this.

The inherited `config:best-practices` preset ignores `**/examples/**`, so Renovate only detects two of this repository's three Go modules:

```
go.mod                     managed
internal/tools/go.mod      managed
internal/examples/go.mod   ignored
```

As a result, the 12 dependencies that are direct requirements of `internal/examples` only have never been updated by Renovate:

```
github.com/knadh/koanf
github.com/oklog/ulid/v2
github.com/shirou/gopsutil
go.opentelemetry.io/collector/config/configopaque
go.opentelemetry.io/collector/config/configtls
go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
go.opentelemetry.io/otel
go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp
go.opentelemetry.io/otel/exporters/stdout/stdoutmetric
go.opentelemetry.io/otel/metric
go.opentelemetry.io/otel/sdk
go.opentelemetry.io/otel/sdk/metric
```

Setting `"ignorePaths": []` brings the module under management.

## Heads-up on the first run

This will produce a batch of PRs the first time Renovate runs, and some of them are major-version bumps that will need code changes rather than a clean merge:

- `koanf v1.3.3` — v2 is current
- `gopsutil v3.21.11+incompatible` — v4 is current
- `otelhttp v0.49.0` and `otlpmetrichttp v1.24.0` are well behind the other `otel` packages in the same module

If that batch is unwelcome right now, options include landing this alongside a `dependencyDashboardApproval` setting, or grouping the `otel`/`collector` packages so they arrive as fewer PRs. Happy to adjust — or to just close this and revisit later.

## Aside

This also slightly reduces how often the `go mod tidy` workflow has to do anything, since 4 of the root module's direct dependencies (`backoff/v4`, `uuid`, `testify`, `protobuf`) are also direct requirements of `internal/examples` and would then be updated in both modules by Renovate itself. It does not remove the need for that workflow: `internal/examples` has `replace github.com/open-telemetry/opamp-go => ../../`, so root-only dependencies such as `gorilla/websocket` and `madflojo/testcerts` remain indirect requirements there, and Renovate does not raise updates for indirect dependencies.
