### PR TITLE
Fix example UI links behind path-prefix proxies

### DIFF
--- a/internal/examples/html/html/agent.html
+++ b/internal/examples/html/html/agent.html
@@ -1,6 +1,6 @@
 {{ template "header.html" . }}
 
-<a href="/">Back to Agents List</a>
+<a href="./">Back to Agents List</a>
 
 <style>
     td {
@@ -91,7 +91,7 @@
         </td>
         <td valign="top">
             Additional Configuration:<br/>
-            <form action="/save_config" method="post">
+            <form action="save_config" method="post">
             <input type="hidden" name="instanceid" value="{{ .InstanceIdStr }}"/>
             <textarea rows="20" name="config">{{ .CustomInstanceConfig }}</textarea><br/>
              {{if .Status.RemoteConfigStatus }}
@@ -137,7 +137,7 @@
 {{end}}
 
 <br/>
-<form action="/rotate_client_cert" method="post">
+<form action="rotate_client_cert" method="post">
     <input type="hidden" name="instanceid" value="{{ .InstanceIdStr }}"/>
     {{if .ClientCert}}
     <input type="submit" value="Rotate Client Certificate"/>
@@ -150,7 +150,7 @@
 
 <br/>
 
-<form action="/opamp_connection_settings" method="post">
+<form action="opamp_connection_settings" method="post">
     <input type="hidden" name="instanceid" value="{{ .InstanceIdStr }}"/>
     <input type="radio" name="tls_min" value="TLSv1.0">
       <label for="TLSv1.0">TLSv1.0</label><br/>
@@ -175,7 +175,7 @@
 <h3>Custom Messages</h3>
 
 <h4>Send Custom Message</h4>
-<form action="/send_custom_message" method="post">
+<form action="send_custom_message" method="post">
     <input type="hidden" name="instanceid" value="{{ .InstanceIdStr }}"/>
     
     <label for="capability">Capability:</label>

--- a/internal/examples/server/uisrv/ui.go
+++ b/internal/examples/server/uisrv/ui.go
@@ -83,6 +83,10 @@ func renderAgent(w http.ResponseWriter, r *http.Request) {
 	renderTemplate(w, "agent.html", agent)
 }
 
+func agentPath(uid uuid.UUID) string {
+	return "agent?instanceid=" + uid.String()
+}
+
 func sendCustomMessage(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -116,7 +120,7 @@ func sendCustomMessage(w http.ResponseWriter, r *http.Request) {
 
 	data.AllAgents.SendCustomMessageToAgent(instanceId, customMsg)
 
-	http.Redirect(w, r, "/agent?instanceid="+uid.String(), http.StatusSeeOther)
+	http.Redirect(w, r, agentPath(uid), http.StatusSeeOther)
 }
 
 func saveCustomConfigForInstance(w http.ResponseWriter, r *http.Request) {
@@ -157,7 +161,7 @@ func saveCustomConfigForInstance(w http.ResponseWriter, r *http.Request) {
 	case <-timer.C:
 	}
 
-	http.Redirect(w, r, "/agent?instanceid="+uid.String(), http.StatusSeeOther)
+	http.Redirect(w, r, agentPath(uid), http.StatusSeeOther)
 }
 
 func rotateInstanceClientCert(w http.ResponseWriter, r *http.Request) {
@@ -211,7 +215,7 @@ func rotateInstanceClientCert(w http.ResponseWriter, r *http.Request) {
 		logger.Printf("Time out waiting for agent %x to reconnect\n", instanceId)
 	}
 
-	http.Redirect(w, r, "/agent?instanceid="+uid.String(), http.StatusSeeOther)
+	http.Redirect(w, r, agentPath(uid), http.StatusSeeOther)
 }
 
 func opampConnectionSettings(w http.ResponseWriter, r *http.Request) {
@@ -289,5 +293,5 @@ func opampConnectionSettings(w http.ResponseWriter, r *http.Request) {
 		logger.Printf("Time out waiting for agent %x to reconnect\n", instanceId)
 	}
 
-	http.Redirect(w, r, "/agent?instanceid="+uid.String(), http.StatusSeeOther)
+	http.Redirect(w, r, agentPath(uid), http.StatusSeeOther)
 }

--- a/internal/examples/server/uisrv/ui_test.go
+++ b/internal/examples/server/uisrv/ui_test.go
@@ -1,0 +1,32 @@
+package uisrv
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	exampleshtml "github.com/open-telemetry/opamp-go/internal/examples/html"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentPathPreservesProxyPrefix(t *testing.T) {
+	instanceID := uuid.MustParse("01234567-89ab-cdef-0123-456789abcdef")
+	requestURL, err := url.Parse("https://example.com/opamp/save_config")
+	require.NoError(t, err)
+	redirectURL, err := url.Parse(agentPath(instanceID))
+	require.NoError(t, err)
+
+	require.Equal(
+		t,
+		"https://example.com/opamp/agent?instanceid=01234567-89ab-cdef-0123-456789abcdef",
+		requestURL.ResolveReference(redirectURL).String(),
+	)
+}
+
+func TestAgentTemplateUsesRelativeInternalURLs(t *testing.T) {
+	template, err := exampleshtml.HtmlFS.ReadFile("html/agent.html")
+	require.NoError(t, err)
+
+	require.NotContains(t, string(template), `href="/"`)
+	require.NotContains(t, string(template), `action="/`)
+}


### PR DESCRIPTION
## Description

The example server UI uses root-absolute links, form actions, and redirects, which escape a reverse proxy path prefix such as `/opamp/`. Use relative internal URLs so the UI works both at the server root and behind a path-prefix proxy.

Add regression coverage for template actions and redirect resolution through a prefixed URL.

## Testing

- `cd internal/examples && go test ./server/uisrv`
- `cd internal/examples && go build -o /tmp/opamp-server ./server`