### PR TITLE
Require POST for example UI mutations

### DIFF
--- a/internal/examples/server/uisrv/ui.go
+++ b/internal/examples/server/uisrv/ui.go
@@ -27,20 +27,35 @@ var logger = log.New(log.Default().Writer(), "[UI] ", log.Default().Flags()|log.
 func Start(rootDir string) {
 	htmlDir = path.Join(rootDir, "uisrv/html")
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", renderRoot)
-	mux.HandleFunc("/agent", renderAgent)
-	mux.HandleFunc("/save_config", saveCustomConfigForInstance)
-	mux.HandleFunc("/rotate_client_cert", rotateInstanceClientCert)
-	mux.HandleFunc("/opamp_connection_settings", opampConnectionSettings)
-	mux.HandleFunc("/send_custom_message", sendCustomMessage)
 	srv = &http.Server{
 		Addr:    "0.0.0.0:4321",
-		Handler: mux,
+		Handler: newUIHandler(),
 	}
 	go srv.ListenAndServe()
 
 	logger.Printf("Admin UI started, available at http://localhost:4321")
+}
+
+func newUIHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", renderRoot)
+	mux.HandleFunc("/agent", renderAgent)
+	mux.HandleFunc("/save_config", postOnly(saveCustomConfigForInstance))
+	mux.HandleFunc("/rotate_client_cert", postOnly(rotateInstanceClientCert))
+	mux.HandleFunc("/opamp_connection_settings", postOnly(opampConnectionSettings))
+	mux.HandleFunc("/send_custom_message", postOnly(sendCustomMessage))
+	return mux
+}
+
+func postOnly(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		next(w, r)
+	}
 }
 
 func Shutdown() {

--- a/internal/examples/server/uisrv/ui_test.go
+++ b/internal/examples/server/uisrv/ui_test.go
@@ -17,27 +17,20 @@ func TestMutationEndpointsRequirePost(t *testing.T) {
 		"/send_custom_message",
 	} {
 		t.Run(endpoint, func(t *testing.T) {
-			request := httptest.NewRequest(http.MethodGet, endpoint, nil)
-			response := httptest.NewRecorder()
+			getRequest := httptest.NewRequest(http.MethodGet, endpoint, nil)
+			getResponse := httptest.NewRecorder()
 
-			handler.ServeHTTP(response, request)
+			handler.ServeHTTP(getResponse, getRequest)
 
-			require.Equal(t, http.StatusMethodNotAllowed, response.Code)
-			require.Equal(t, http.MethodPost, response.Header().Get("Allow"))
+			require.Equal(t, http.StatusMethodNotAllowed, getResponse.Code)
+			require.Equal(t, http.MethodPost, getResponse.Header().Get("Allow"))
+
+			postRequest := httptest.NewRequest(http.MethodPost, endpoint, nil)
+			postResponse := httptest.NewRecorder()
+
+			handler.ServeHTTP(postResponse, postRequest)
+
+			require.NotEqual(t, http.StatusMethodNotAllowed, postResponse.Code)
 		})
 	}
-}
-
-func TestPostOnlyAllowsPost(t *testing.T) {
-	called := false
-	handler := postOnly(func(http.ResponseWriter, *http.Request) {
-		called = true
-	})
-
-	handler.ServeHTTP(
-		httptest.NewRecorder(),
-		httptest.NewRequest(http.MethodPost, "/", nil),
-	)
-
-	require.True(t, called)
 }

--- a/internal/examples/server/uisrv/ui_test.go
+++ b/internal/examples/server/uisrv/ui_test.go
@@ -1,0 +1,43 @@
+package uisrv
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMutationEndpointsRequirePost(t *testing.T) {
+	handler := newUIHandler()
+	for _, endpoint := range []string{
+		"/save_config",
+		"/rotate_client_cert",
+		"/opamp_connection_settings",
+		"/send_custom_message",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, endpoint, nil)
+			response := httptest.NewRecorder()
+
+			handler.ServeHTTP(response, request)
+
+			require.Equal(t, http.StatusMethodNotAllowed, response.Code)
+			require.Equal(t, http.MethodPost, response.Header().Get("Allow"))
+		})
+	}
+}
+
+func TestPostOnlyAllowsPost(t *testing.T) {
+	called := false
+	handler := postOnly(func(http.ResponseWriter, *http.Request) {
+		called = true
+	})
+
+	handler.ServeHTTP(
+		httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+	)
+
+	require.True(t, called)
+}


### PR DESCRIPTION
## Description

While integrating the example server UI into the OpenTelemetry Demo, I noticed that its state-changing handlers accept any HTTP method. The forms submit POST requests, but the server does not enforce that requirement, allowing GET requests to reach mutation handlers.

Require POST for saving remote configuration, rotating client certificates, changing OpAMP connection settings, and sending custom messages. Other methods now receive `405 Method Not Allowed` with `Allow: POST`; read-only routes are unchanged.

## Testing

- `cd internal/examples && go test ./server/uisrv`
- `cd internal/examples && go build -o /tmp/opamp-server ./server`