### PR TITLE
Handle SIGTERM in example server

### DIFF
--- a/internal/examples/server/main.go
+++ b/internal/examples/server/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/open-telemetry/opamp-go/internal/examples/server/data"
 	"github.com/open-telemetry/opamp-go/internal/examples/server/opampsrv"
@@ -36,7 +37,7 @@ func main() {
 	logger.Println("OpAMP Server running...")
 
 	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
 	<-interrupt
 
 	logger.Println("OpAMP Server shutting down...")


### PR DESCRIPTION
## Description

The example server currently waits only for `os.Interrupt`. Container runtimes such as Docker send SIGTERM by default when stopping a container, so the process exits through the default signal behavior and skips `uisrv.Shutdown()` and `opampSrv.Stop()`.

Subscribe to SIGTERM alongside `os.Interrupt` so both interactive and container shutdown reach the existing cleanup path. This was found while integrating the example server into the OpenTelemetry Demo.

## Testing

- `cd internal/examples && go test ./server/...`
- `cd internal/examples && go build -o /tmp/opamp-server ./server`