### PR TITLE
Set ServerToAgent.Capabilities in the example server

### DIFF
--- a/internal/examples/server/opampsrv/opampsrv.go
+++ b/internal/examples/server/opampsrv/opampsrv.go
@@ -108,9 +108,17 @@ func (srv *Server) onDisconnect(conn types.Connection) {
 	srv.agents.RemoveConnection(conn)
 }
 
+// serverCapabilities is the set of OpAMP capabilities this example Server
+// implements. It must be reported in the first ServerToAgent on a connection.
+const serverCapabilities = uint64(protobufs.ServerCapabilities_ServerCapabilities_AcceptsStatus |
+	protobufs.ServerCapabilities_ServerCapabilities_OffersRemoteConfig |
+	protobufs.ServerCapabilities_ServerCapabilities_AcceptsEffectiveConfig |
+	protobufs.ServerCapabilities_ServerCapabilities_OffersConnectionSettings |
+	protobufs.ServerCapabilities_ServerCapabilities_AcceptsConnectionSettingsRequest)
+
 func (srv *Server) onMessage(ctx context.Context, conn types.Connection, msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
 	// Start building the response.
-	response := &protobufs.ServerToAgent{}
+	response := &protobufs.ServerToAgent{Capabilities: serverCapabilities}
 
 	var instanceId data.InstanceId
 	if len(msg.InstanceUid) == 26 {

--- a/internal/examples/server/opampsrv/opampsrv_test.go
+++ b/internal/examples/server/opampsrv/opampsrv_test.go
@@ -1,0 +1,57 @@
+package opampsrv
+
+import (
+	"context"
+	"io"
+	"log"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opamp-go/internal/examples/server/data"
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+// fakeConnection is a types.Connection that does nothing. It must be a
+// comparable type because Agents stores connections as map keys.
+type fakeConnection struct {
+	id int
+}
+
+func (fakeConnection) Connection() net.Conn { return nil }
+
+func (fakeConnection) Send(context.Context, *protobufs.ServerToAgent) error { return nil }
+
+func (fakeConnection) Disconnect() error { return nil }
+
+func newTestServer() *Server {
+	return &Server{
+		agents: &data.AllAgents,
+		logger: &Logger{log.New(io.Discard, "", 0)},
+	}
+}
+
+// The Server must report its capabilities in the first ServerToAgent message
+// it sends on a connection, otherwise the Agent cannot know which features it
+// may use.
+func TestOnMessageReportsServerCapabilities(t *testing.T) {
+	srv := newTestServer()
+	conn := fakeConnection{id: 1}
+	defer srv.agents.RemoveConnection(conn)
+
+	response := srv.onMessage(context.Background(), conn, &protobufs.AgentToServer{
+		InstanceUid: []byte("0123456789abcdef"),
+		SequenceNum: 1,
+	})
+
+	require.NotNil(t, response)
+	assert.Equal(t,
+		uint64(protobufs.ServerCapabilities_ServerCapabilities_AcceptsStatus|
+			protobufs.ServerCapabilities_ServerCapabilities_OffersRemoteConfig|
+			protobufs.ServerCapabilities_ServerCapabilities_AcceptsEffectiveConfig|
+			protobufs.ServerCapabilities_ServerCapabilities_OffersConnectionSettings|
+			protobufs.ServerCapabilities_ServerCapabilities_AcceptsConnectionSettingsRequest),
+		response.Capabilities)
+}


### PR DESCRIPTION
Fixes #640

## Description

The spec says the Server must set `ServerToAgent.capabilities` in the first `ServerToAgent`
it sends on a connection, and may set it in later ones. The example server never set the
field at all, so an agent talking to it had no way to learn that it offers remote config,
accepts effective config, or offers connection settings.

`onMessage` now sets the example server's capability bitmask on every response it builds.
That is the only place the first `ServerToAgent` on a connection can come from. The other
three places the example constructs one (`SendCustomMessage`, `OfferConnectionSettings`,
`SetCustomConfig`) all reach the agent through `FindAgent`, which returns nil until
`onMessage` has already run `FindOrCreateAgent` for that instance.

The bits reported are the ones the example actually implements:

| Capability | Reported | Why |
| --- | --- | --- |
| `AcceptsStatus` | yes | `Agent.UpdateStatus` consumes the status report |
| `OffersRemoteConfig` | yes | `processStatusUpdate` sets `response.RemoteConfig` |
| `AcceptsEffectiveConfig` | yes | `updateEffectiveConfig` stores it and the UI shows it |
| `OffersConnectionSettings` | yes | `calcConnectionSettings` / `OfferAgentConnectionSettings` |
| `AcceptsConnectionSettingsRequest` | yes | `processConnectionSettingsRequest` handles the CSR |
| `OffersPackages` | no | the example never sets `PackagesAvailable` |
| `AcceptsPackagesStatus` | no | `PackageStatuses` is only logged, never acted on |

I left the two package bits off because the example does no package management, but say the
word if you would rather it advertise them.

## Testing

`go test -race ./...` and `go build ./...` in `internal/examples`, plus a run of the example
server and agent:

```
cd internal/examples
go build -o /tmp/server ./server && go build -o /tmp/agent ./agent
(cd server && /tmp/server &) ; sleep 4 ; (cd agent && /tmp/agent &)
```

Before:

```
[OPAMP] ServerToAgent: InstanceUid=903ea0012c8153739a363bb9a8e48fcb, Flags=[ReportFullState]
```

After:

```
[OPAMP] ServerToAgent: InstanceUid=01a04017629679d48a789e6229002371, RemoteConfigHash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, ConnectionSettingsHash=332019f43c2e3b2cedc5caef3d3a0c3cc117371546faf486f0e858e8cf57b5c7, Capabilities=[AcceptsStatus|OffersRemoteConfig|AcceptsEffectiveConfig|OffersConnectionSettings|AcceptsConnectionSettingsRequest]
```

A unit test covers the bitmask on the response.
