### PR TITLE
feat: UDS transport support

### DIFF
--- a/client/httpclient.go
+++ b/client/httpclient.go
@@ -57,7 +57,13 @@ func (c *httpClient) Start(ctx context.Context, settings types.StartSettings) er
 	c.sender.SetMaxMessageSize(settings.MaxMessageSize)
 
 	// Add TLS configuration into httpClient
-	c.sender.AddTLSConfig(settings.TLSConfig)
+	if err := c.sender.AddTLSConfig(settings.TLSConfig); err != nil {
+		return err
+	}
+
+	if err := c.sender.SetDialContext(settings.DialContext); err != nil {
+		return err
+	}
 
 	if settings.EnableCompression {
 		c.sender.EnableCompression()

--- a/client/internal/clientcommon.go
+++ b/client/internal/clientcommon.go
@@ -24,6 +24,7 @@ var (
 	ErrAcceptsPackagesNotSet                 = errors.New("AcceptsPackages and ReportsPackageStatuses must be set")
 	ErrAvailableComponentsMissing            = errors.New("AvailableComponents is nil")
 	ErrReportsConnectionSettingsStatusNotSet = errors.New("ReportsConnectionSettingsStatus capability is not set")
+	ErrDialContextAndProxyURL                = errors.New("DialContext and ProxyURL cannot both be set")
 
 	errAlreadyStarted                  = errors.New("already started")
 	errCannotStopNotStarted            = errors.New("cannot stop because not started")
@@ -104,6 +105,12 @@ func (c *ClientCommon) PrepareStart(
 ) error {
 	if c.isStarted {
 		return errAlreadyStarted
+	}
+
+	// DialContext replaces the dialing that proxying relies on, so the two
+	// cannot be combined.
+	if settings.DialContext != nil && settings.ProxyURL != "" {
+		return ErrDialContextAndProxyURL
 	}
 	// Deprecated: Use client.SetCapabilities() instead.
 	if settings.Capabilities != 0 {

--- a/client/internal/httpsender.go
+++ b/client/internal/httpsender.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"sync"
@@ -91,7 +92,7 @@ func NewHTTPSender(logger types.Logger) *HTTPSender {
 }
 
 // SetHTTPClient sets the HTTP client used to send OpAMP requests.
-// It must be called before Run, SetProxy, or AddTLSConfig.
+// It must be called before Run, SetProxy, SetDialContext, or AddTLSConfig.
 func (h *HTTPSender) SetHTTPClient(client *http.Client) {
 	h.client = client
 }
@@ -111,18 +112,44 @@ func (h *HTTPSender) SetProxy(proxy string, headers http.Header) error {
 		return url.InvalidHostError(proxy)
 	}
 
-	proxyTransport := &http.Transport{}
-	if h.client.Transport != nil {
-		transport, ok := h.client.Transport.(*http.Transport)
-		if !ok {
-			return fmt.Errorf("unable to coorce client transport as *http.Transport detected type is: %T", h.client.Transport)
-		}
-		proxyTransport = transport.Clone()
+	proxyTransport, err := h.cloneTransport()
+	if err != nil {
+		return err
 	}
 	proxyTransport.Proxy = http.ProxyURL(proxyURL)
 	proxyTransport.ProxyConnectHeader = headers
 	h.client.Transport = proxyTransport
 	return nil
+}
+
+// SetDialContext overrides how the underlying network connection is established,
+// e.g. to dial a Unix domain socket.
+// This method is not thread safe and must be called before h.client is used.
+func (h *HTTPSender) SetDialContext(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) error {
+	if dialContext == nil {
+		return nil
+	}
+	transport, err := h.cloneTransport()
+	if err != nil {
+		return err
+	}
+	transport.DialContext = dialContext
+	h.client.Transport = transport
+	return nil
+}
+
+// cloneTransport returns a copy of the client's transport suitable for modification,
+// or a fresh transport if none is set. It returns an error if the transport is not
+// an *http.Transport, since its settings could not be preserved.
+func (h *HTTPSender) cloneTransport() (*http.Transport, error) {
+	if h.client.Transport == nil {
+		return &http.Transport{}, nil
+	}
+	transport, ok := h.client.Transport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("unable to coerce client transport as *http.Transport detected type is: %T", h.client.Transport)
+	}
+	return transport.Clone(), nil
 }
 
 // Run starts the processing loop that will perform the HTTP request/response.
@@ -483,15 +510,17 @@ func (h *HTTPSender) SetMaxMessageSize(maxMessageSize int64) {
 	h.maxMessageSize = internal.ResolveMaxMessageSize(maxMessageSize)
 }
 
-func (h *HTTPSender) AddTLSConfig(config *tls.Config) {
-	if config != nil {
-		tlsTransport := &http.Transport{}
-		if h.client.Transport != nil {
-			if transport, ok := h.client.Transport.(*http.Transport); ok {
-				tlsTransport = transport.Clone()
-			}
-		}
-		tlsTransport.TLSClientConfig = config
-		h.client.Transport = tlsTransport
+// AddTLSConfig sets the TLS configuration on the client's transport.
+// This method is not thread safe and must be called before h.client is used.
+func (h *HTTPSender) AddTLSConfig(config *tls.Config) error {
+	if config == nil {
+		return nil
 	}
+	tlsTransport, err := h.cloneTransport()
+	if err != nil {
+		return err
+	}
+	tlsTransport.TLSClientConfig = config
+	h.client.Transport = tlsTransport
+	return nil
 }

--- a/client/internal/httpsender_test.go
+++ b/client/internal/httpsender_test.go
@@ -113,6 +113,7 @@ func TestAddTLSConfig(t *testing.T) {
 		name              string
 		existingTransport http.RoundTripper
 		tlsConfig         *tls.Config
+		wantErr           bool
 		validateFunc      func(*testing.T, *HTTPSender)
 	}{
 		{
@@ -169,11 +170,10 @@ func TestAddTLSConfig(t *testing.T) {
 			name:              "non-*http.Transport",
 			existingTransport: &customTransport{},
 			tlsConfig:         tlsConfig,
+			wantErr:           true,
 			validateFunc: func(t *testing.T, sender *HTTPSender) {
-				transport, ok := sender.client.Transport.(*http.Transport)
-				assert.True(t, ok, "transport should be *http.Transport")
-				assert.NotNil(t, transport.TLSClientConfig)
-				assert.Equal(t, tlsConfig, transport.TLSClientConfig)
+				_, ok := sender.client.Transport.(*customTransport)
+				assert.True(t, ok, "custom transport should be left untouched on error")
 			},
 		},
 	}
@@ -183,7 +183,12 @@ func TestAddTLSConfig(t *testing.T) {
 			sender := newTestHTTPSender()
 			sender.client.Transport = tc.existingTransport
 
-			sender.AddTLSConfig(tc.tlsConfig)
+			err := sender.AddTLSConfig(tc.tlsConfig)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 
 			tc.validateFunc(t, sender)
 		})

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -58,7 +58,8 @@ type StartSettings struct {
 	// header (e.g. "ws://localhost/v1/opamp" or "http://localhost/v1/opamp").
 	// For the HTTP transport, Client.Transport must be an *http.Transport (or
 	// nil) so the dialer can be applied; Start() returns an error otherwise.
-	// Setting both DialContext and ProxyURL is not supported.
+	// Setting both DialContext and ProxyURL is not supported; Start() returns
+	// an error if both are set.
 	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	// Optional Proxy configuration

--- a/client/types/startsettings.go
+++ b/client/types/startsettings.go
@@ -1,7 +1,9 @@
 package types
 
 import (
+	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"time"
 
@@ -41,6 +43,23 @@ type StartSettings struct {
 
 	// Optional TLS config for HTTP connection.
 	TLSConfig *tls.Config
+
+	// DialContext, if set, overrides how the client establishes the underlying
+	// network connection. The network and addr arguments passed to it are
+	// derived from OpAMPServerURL but may be ignored by the implementation,
+	// e.g. to dial a filesystem-path Unix domain socket regardless of the
+	// (cosmetic) OpAMPServerURL host:
+	//
+	//   DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+	//       return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+	//   }
+	//
+	// In that case OpAMPServerURL still supplies the scheme, path, and Host
+	// header (e.g. "ws://localhost/v1/opamp" or "http://localhost/v1/opamp").
+	// For the HTTP transport, Client.Transport must be an *http.Transport (or
+	// nil) so the dialer can be applied; Start() returns an error otherwise.
+	// Setting both DialContext and ProxyURL is not supported.
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	// Optional Proxy configuration
 	// The ProxyURL may be http(s) or socks5; if no schema is specified http is assumed.

--- a/client/uds_test.go
+++ b/client/uds_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package client
 
 import (
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opamp-go/client/internal"
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/open-telemetry/opamp-go/server"
@@ -140,4 +143,20 @@ func TestHTTPClientDialContextRejectsCustomTransport(t *testing.T) {
 	}
 	prepareClient(t, &settings, client)
 	require.Error(t, client.Start(context.Background(), settings))
+}
+
+// TestDialContextRejectsProxy verifies Start fails when both DialContext and
+// ProxyURL are set, since DialContext replaces the dialing proxying relies on.
+func TestDialContextRejectsProxy(t *testing.T) {
+	testClients(t, func(t *testing.T, client OpAMPClient) {
+		settings := types.StartSettings{
+			OpAMPServerURL: "ws://localhost/v1/opamp",
+			ProxyURL:       "http://localhost:3128",
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return nil, nil
+			},
+		}
+		prepareClient(t, &settings, client)
+		require.ErrorIs(t, client.Start(context.Background(), settings), internal.ErrDialContextAndProxyURL)
+	})
 }

--- a/client/uds_test.go
+++ b/client/uds_test.go
@@ -1,0 +1,143 @@
+package client
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opamp-go/client/types"
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/open-telemetry/opamp-go/server"
+	servertypes "github.com/open-telemetry/opamp-go/server/types"
+)
+
+// unixSocketServer is a test OpAMP server listening on a Unix domain socket.
+type unixSocketServer struct {
+	socketPath string
+	gotMessage chan *protobufs.AgentToServer
+}
+
+// startUnixSocketServer starts an OpAMP server on a filesystem-path Unix domain
+// socket using the server-side Listener injection. No TCP/UDP port is opened.
+func startUnixSocketServer(t *testing.T) *unixSocketServer {
+	// t.TempDir() paths can exceed the 104-byte sun_path limit on macOS, so use a
+	// short temp dir instead.
+	dir, err := os.MkdirTemp("", "o")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	s := &unixSocketServer{
+		socketPath: filepath.Join(dir, "opamp.sock"),
+		gotMessage: make(chan *protobufs.AgentToServer, 1),
+	}
+
+	ln, err := net.Listen("unix", s.socketPath)
+	require.NoError(t, err)
+
+	callbacks := servertypes.Callbacks{
+		OnConnecting: func(_ *http.Request) servertypes.ConnectionResponse {
+			return servertypes.ConnectionResponse{
+				Accept: true,
+				ConnectionCallbacks: servertypes.ConnectionCallbacks{
+					OnMessage: func(_ context.Context, conn servertypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+						// The underlying conn must be a Unix socket so that the
+						// consumer can authenticate the peer via SO_PEERCRED.
+						_, ok := conn.Connection().(*net.UnixConn)
+						assert.True(t, ok, "server-side connection should be a *net.UnixConn")
+						select {
+						case s.gotMessage <- message:
+						default:
+						}
+						return &protobufs.ServerToAgent{InstanceUid: message.InstanceUid}
+					},
+				},
+			}
+		},
+	}
+
+	srv := server.New(nil)
+	require.NoError(t, srv.Start(server.StartSettings{
+		Settings:   server.Settings{Callbacks: callbacks},
+		Listener:   ln,
+		ListenPath: "/v1/opamp",
+	}))
+	t.Cleanup(func() { srv.Stop(context.Background()) })
+
+	// The server must be listening on the Unix socket, not on a TCP/UDP port.
+	require.Equal(t, "unix", srv.Addr().Network())
+	require.Equal(t, s.socketPath, srv.Addr().String())
+	return s
+}
+
+func (s *unixSocketServer) dialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, "unix", s.socketPath)
+}
+
+// requireMessage waits for the first AgentToServer message, which proves the
+// full handshake over the Unix socket completed.
+func (s *unixSocketServer) requireMessage(t *testing.T) {
+	select {
+	case msg := <-s.gotMessage:
+		assert.NotNil(t, msg)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the first AgentToServer message over the Unix socket")
+	}
+}
+
+// TestWSClientOverUnixSocket exercises the full WebSocket OpAMP handshake over a
+// Unix domain socket using the client-side DialContext hook.
+func TestWSClientOverUnixSocket(t *testing.T) {
+	srv := startUnixSocketServer(t)
+
+	client := NewWebSocket(nil)
+	settings := types.StartSettings{
+		// The URL host is cosmetic; DialContext dials the socket regardless.
+		OpAMPServerURL: "ws://localhost/v1/opamp",
+		DialContext:    srv.dialContext,
+	}
+	prepareClient(t, &settings, client)
+	require.NoError(t, client.Start(context.Background(), settings))
+	defer client.Stop(context.Background())
+
+	srv.requireMessage(t)
+}
+
+// TestHTTPClientOverUnixSocket exercises the plain HTTP OpAMP transport over a
+// Unix domain socket using the client-side DialContext hook.
+func TestHTTPClientOverUnixSocket(t *testing.T) {
+	srv := startUnixSocketServer(t)
+
+	client := NewHTTP(nil)
+	settings := types.StartSettings{
+		OpAMPServerURL: "http://localhost/v1/opamp",
+		DialContext:    srv.dialContext,
+	}
+	prepareClient(t, &settings, client)
+	require.NoError(t, client.Start(context.Background(), settings))
+	defer client.Stop(context.Background())
+
+	srv.requireMessage(t)
+}
+
+// TestHTTPClientDialContextRejectsCustomTransport verifies the HTTP transport
+// fails loudly when DialContext cannot be applied to a non-*http.Transport
+// Client, instead of silently dropping it.
+func TestHTTPClientDialContextRejectsCustomTransport(t *testing.T) {
+	client := NewHTTP(nil)
+	settings := types.StartSettings{
+		OpAMPServerURL: "http://localhost/v1/opamp",
+		Client:         &http.Client{Transport: &recordingRoundTripper{base: http.DefaultTransport}},
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return nil, nil
+		},
+	}
+	prepareClient(t, &settings, client)
+	require.Error(t, client.Start(context.Background(), settings))
+}

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -115,8 +115,9 @@ func (c *wsClient) Start(ctx context.Context, settings types.StartSettings) erro
 	c.dialer.TLSClientConfig = settings.TLSConfig
 
 	// Allow the caller to override how the underlying network connection is
-	// established, e.g. to dial a Unix domain socket. This must be applied
-	// after useProxy, which also writes NetDialContext, so it takes precedence.
+	// established, e.g. to dial a Unix domain socket. PrepareStart rejects
+	// combining this with ProxyURL, so this cannot clash with the
+	// NetDialContext that useProxy installs.
 	if settings.DialContext != nil {
 		c.dialer.NetDialContext = settings.DialContext
 	}

--- a/client/wsclient.go
+++ b/client/wsclient.go
@@ -114,6 +114,13 @@ func (c *wsClient) Start(ctx context.Context, settings types.StartSettings) erro
 	}
 	c.dialer.TLSClientConfig = settings.TLSConfig
 
+	// Allow the caller to override how the underlying network connection is
+	// established, e.g. to dial a Unix domain socket. This must be applied
+	// after useProxy, which also writes NetDialContext, so it takes precedence.
+	if settings.DialContext != nil {
+		c.dialer.NetDialContext = settings.DialContext
+	}
+
 	headerFunc := settings.HeaderFunc
 	if headerFunc == nil {
 		headerFunc = func(h http.Header) http.Header {

--- a/server/server.go
+++ b/server/server.go
@@ -42,7 +42,16 @@ type StartSettings struct {
 	Settings
 
 	// ListenEndpoint specifies the endpoint to listen on, e.g. "127.0.0.1:4320"
+	// Ignored if Listener is set.
 	ListenEndpoint string
+
+	// Listener, if set, is used to accept connections instead of opening a TCP
+	// listener on ListenEndpoint. This allows serving OpAMP over an arbitrary
+	// net.Listener, e.g. a filesystem-path Unix domain socket created with
+	// net.Listen("unix", path). When set, ListenEndpoint is ignored. The server
+	// closes the Listener when Stop() is called (via http.Server.Shutdown); the
+	// caller only needs to close it if Start() returns an error.
+	Listener net.Listener
 
 	// ListenPath specifies the URL path on which to accept the OpAMP connections
 	// If this is empty string then Start() will use the default "/v1/opamp" path.

--- a/server/serverimpl.go
+++ b/server/serverimpl.go
@@ -137,6 +137,7 @@ func (s *server) Start(settings StartSettings) error {
 		}
 		err = s.startHttpServer(
 			listenAddr,
+			settings.Listener,
 			func(l net.Listener) error {
 				defer httpServerServeWg.Done()
 				return hs.ServeTLS(l, "", "")
@@ -148,6 +149,7 @@ func (s *server) Start(settings StartSettings) error {
 		}
 		err = s.startHttpServer(
 			listenAddr,
+			settings.Listener,
 			func(l net.Listener) error {
 				defer httpServerServeWg.Done()
 				return hs.Serve(l)
@@ -157,17 +159,21 @@ func (s *server) Start(settings StartSettings) error {
 	return err
 }
 
-func (s *server) startHttpServer(listenAddr string, serveFunc func(l net.Listener) error) error {
-	// If the listen address is not specified use the default.
-	ln, err := net.Listen("tcp", listenAddr)
-	if err != nil {
-		return err
+func (s *server) startHttpServer(listenAddr string, listener net.Listener, serveFunc func(l net.Listener) error) error {
+	ln := listener
+	if ln == nil {
+		// No listener was provided, open a TCP listener on the listen address.
+		var err error
+		ln, err = net.Listen("tcp", listenAddr)
+		if err != nil {
+			return err
+		}
 	}
 	s.addr = ln.Addr()
 
 	// Begin serving connections in the background.
 	go func() {
-		err = serveFunc(ln)
+		err := serveFunc(ln)
 
 		// ErrServerClosed is expected after successful Stop(), so we won't log that
 		// particular error.


### PR DESCRIPTION
Adds support in OpAMP-Go for configuring the client and server to use UDS transport. 

Closes #601.

Unit tests added.